### PR TITLE
Compute per-light shadow-caster cutoff radius from attenuation (#27)

### DIFF
--- a/src/Components/EC_DOD_Components.h
+++ b/src/Components/EC_DOD_Components.h
@@ -93,7 +93,11 @@ struct EC_DOD_Light {
     glm::vec3 direction;
     glm::vec3 colour;
     float intensity;
-    float range;
+    // Distance beyond which this light's contribution falls below a perceptible
+    // threshold (1/256, the smallest step an 8-bit colour channel can represent).
+    // Computed once at load time (see EC_DOD_EntityFactory::parseLight) from
+    // intensity/attenuation - not meaningful for Directional lights (left at 0).
+    float cutoffRadius;
     float cutoffAngle;
     glm::vec3 attenuation;
     bool castsShadow;

--- a/src/Entity/EC_DOD_EntityFactory.cpp
+++ b/src/Entity/EC_DOD_EntityFactory.cpp
@@ -3,6 +3,7 @@
 #include "Logging/ECX_Logging.h"
 #include <sstream>
 #include <unordered_map>
+#include <cmath>
 #include <glm/gtc/constants.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include "Graphics/ObjModel.h"
@@ -640,6 +641,35 @@ ECXEventType EC_DOD_EntityFactory::getEventTypeFromHandlerName(const std::string
     return (it != handlerMap.end()) ? it->second : ECXEventType::None;
 }
 
+namespace {
+    // Distance at which this light's intensity, attenuated per the standard
+    // 1/(Kc + Kl*d + Kq*d^2) falloff, drops below 1/256 - the smallest step an
+    // 8-bit colour channel can represent. Solves Kq*d^2 + Kl*d + (Kc - intensity*256) = 0.
+    float computeLightCutoffRadius(float intensity, const glm::vec3& attenuation) {
+        const float Kc = attenuation.x;
+        const float Kl = attenuation.y;
+        const float Kq = attenuation.z;
+        const float threshold = intensity * 256.0f;
+
+        if (Kq > 0.0f) {
+            const float discriminant = Kl * Kl - 4.0f * Kq * (Kc - threshold);
+            if (discriminant > 0.0f) {
+                const float d = (-Kl + std::sqrt(discriminant)) / (2.0f * Kq);
+                if (d > 0.0f) return d;
+            }
+        }
+        else if (Kl > 0.0f) {
+            const float d = (threshold - Kc) / Kl;
+            if (d > 0.0f) return d;
+        }
+
+        // No quadratic/linear falloff term (or a degenerate one) - the light
+        // doesn't naturally attenuate to imperceptibility, so fall back to a
+        // generous fixed radius rather than treating it as infinite.
+        return 100.0f;
+    }
+}
+
 void EC_DOD_EntityFactory::parseLight(TiXmlElement* elem, EntityID entity) {
     auto& manager = EC_DOD_EntityManager::getInstance();
     EC_DOD_Light light;
@@ -673,6 +703,10 @@ void EC_DOD_EntityFactory::parseLight(TiXmlElement* elem, EntityID entity) {
             light.dynamic = (strcmp(child->GetText(), "true") == 0);
         child = child->NextSiblingElement();
     }
+
+    light.cutoffRadius = (light.type != EC_DOD_Light::Type::Directional)
+        ? computeLightCutoffRadius(light.intensity, light.attenuation)
+        : 0.0f;
 
     manager.addComponent(entity, light);
 }

--- a/src/Graphics/GL_Deferred_Renderer.cpp
+++ b/src/Graphics/GL_Deferred_Renderer.cpp
@@ -340,6 +340,8 @@ void GL_Deferred_Renderer::updateLights(EC_GameScene& scene)
     m_ShadowDirs.clear();
     m_ShadowSpots.clear();
     m_ShadowPoints.clear();
+    m_ShadowSpotRadii.clear();
+    m_ShadowPointRadii.clear();
 
     auto& manager = EC_DOD_EntityManager::getInstance();
 
@@ -366,7 +368,10 @@ void GL_Deferred_Renderer::updateLights(EC_GameScene& scene)
             data.cutoffAngle = light.cutoffAngle;
             data.attenuation = glm::vec4(light.attenuation, 0.0f);
             if (!light.castsShadow) m_Spots.push_back(data);
-            else m_ShadowSpots.push_back(data);
+            else {
+                m_ShadowSpots.push_back(data);
+                m_ShadowSpotRadii.push_back(light.cutoffRadius);
+            }
         }
         else {
             LightData data;
@@ -375,7 +380,10 @@ void GL_Deferred_Renderer::updateLights(EC_GameScene& scene)
             data.intensity = light.intensity;
             data.attenuation = glm::vec4(light.attenuation, 0.0f);
             if (!light.castsShadow) m_Points.push_back(data);
-            else m_ShadowPoints.push_back(data);
+            else {
+                m_ShadowPoints.push_back(data);
+                m_ShadowPointRadii.push_back(light.cutoffRadius);
+            }
         }
     }
 }
@@ -556,9 +564,10 @@ void GL_Deferred_Renderer::shadowLightingPass(EC_GameScene& scene)
         // Shadow casters are never narrowed by camera visibility - an entity fully
         // outside the camera's frustum can still cast a shadow onto something that is
         // visible. Each shadow pass gets only the light's own influence radius.
-        // Directional lights have no meaningful world position, so this queries
-        // around the camera instead, purely as a bounding heuristic (not a visibility
-        // test).
+        // Directional lights have no meaningful world position or cutoff radius, so
+        // this queries around the camera instead, purely as a bounding heuristic (not
+        // a visibility test). Spot/point lights use their cached per-light cutoff
+        // radius (EC_DOD_Light::cutoffRadius) instead.
         auto dirCasters = queryEntitiesNear(spatial.position, m_ShadowQueryRadius);
         for (size_t i = 0; i < m_ShadowDirs.size(); i++)
         {
@@ -577,7 +586,7 @@ void GL_Deferred_Renderer::shadowLightingPass(EC_GameScene& scene)
 
         for (size_t i = 0; i < m_ShadowSpots.size(); i++)
         {
-            auto nearby = queryEntitiesNear(glm::vec3(m_ShadowSpots[i].position), m_ShadowQueryRadius);
+            auto nearby = queryEntitiesNear(glm::vec3(m_ShadowSpots[i].position), m_ShadowSpotRadii[i]);
             shadowSpotPass(m_ShadowBuffer, m_ShadowSpots[i], nearby);
             m_ShadowSpotLightShader.activate();
             m_FrameBuffer.LightingPass(m_ShadowSpotLightShader);
@@ -596,7 +605,7 @@ void GL_Deferred_Renderer::shadowLightingPass(EC_GameScene& scene)
         // full entity list per face.
         for (size_t i = 0; i < m_ShadowPoints.size(); i++)
         {
-            auto nearby = queryEntitiesNear(glm::vec3(m_ShadowPoints[i].position), m_ShadowQueryRadius);
+            auto nearby = queryEntitiesNear(glm::vec3(m_ShadowPoints[i].position), m_ShadowPointRadii[i]);
             shadowPointPass(m_PointShadowBuffer, m_ShadowPoints[i], nearby);
             m_ShadowPointLightShader.activate();
             m_FrameBuffer.LightingPass(m_ShadowPointLightShader);

--- a/src/Graphics/GL_Deferred_Renderer.h
+++ b/src/Graphics/GL_Deferred_Renderer.h
@@ -64,8 +64,9 @@ private:
     // visible, so narrowing shadow casters by camera visibility is wrong, not just an
     // optimization detail.
     std::vector<EntityID> m_VisibleEntities;
-    // Placeholder query radius for shadow-caster influence searches (all three light
-    // types). The real per-light cutoff-radius formula (Issue 3) doesn't exist yet.
+    // Directional lights have no meaningful world position/radius, so their shadow-
+    // caster search is a bounding heuristic around the camera instead of a per-light
+    // cutoff radius (see EC_DOD_Light::cutoffRadius, used by spot/point lights).
     float m_ShadowQueryRadius = 100.0f;
 
     std::mutex m_Lock;
@@ -103,5 +104,10 @@ private:
     std::vector<DirLightData> m_ShadowDirs;
     std::vector<LightData> m_ShadowPoints;
     std::vector<SpotLightData> m_ShadowSpots;
+    // Cached cutoff radius for each entry in m_ShadowPoints/m_ShadowSpots, indices
+    // aligned 1:1. Copied from EC_DOD_Light::cutoffRadius in updateLights() - not
+    // recomputed here, since the radius only depends on light data set at load time.
+    std::vector<float> m_ShadowPointRadii;
+    std::vector<float> m_ShadowSpotRadii;
     GL_DebugRenderer m_DebugRenderer;
 };


### PR DESCRIPTION
Shadow-caster influence queries for spot/point lights used a flat placeholder radius (100 units) regardless of the light's actual intensity/attenuation. EC_DOD_Light now caches a real cutoff radius, computed once at scene-load time in parseLight() from the light's attenuation coefficients and intensity - the distance at which its contribution drops below 1/256 (imperceptible in 8-bit colour). Directional lights are exempt (no meaningful position/radius).

updateLights() carries the cached radius alongside each shadow-casting spot/point light into new parallel arrays, and shadowLightingPass() uses it in place of the placeholder when querying nearby casters.