### PR TITLE
Fix deactivated scenes continuing to render/collide after a scene switch

### DIFF
--- a/src/Engine/Subsystems/CollisionSystems/EC_BroadPhase.cpp
+++ b/src/Engine/Subsystems/CollisionSystems/EC_BroadPhase.cpp
@@ -36,6 +36,17 @@ void EC_BroadPhase::broadPhaseCollisionDetection()
             localAABBs.reserve(entities.size());
 
             for (uint32_t entityId : entities) {
+                // A deactivated scene's entities (EC_GameScene::deactivate(), on
+                // switching scenes) must drop out of the spatial index entirely - this
+                // is the single point rendering (via queryVisibleEntities), gameplay
+                // collision, and ray/cone queries all read from, so filtering here is
+                // what actually stops a deactivated scene's geometry from continuing to
+                // render/collide/hit-test after a scene switch. EC_DOD_EntityInfo::active
+                // was previously written by scene activation but never read anywhere.
+                if (EC_DOD_EntityManager::getInstance().hasComponent<EC_DOD_EntityInfo>(entityId) &&
+                    !EC_DOD_EntityManager::getInstance().getComponent<EC_DOD_EntityInfo>(entityId).active)
+                    continue;
+
                 // Lock and get components (get() has its own locking)
                 EC_DOD_Collider collider;
                 EC_DOD_Spatial spatial;


### PR DESCRIPTION
EC_GameScene::deactivate() (called by EC_SceneManager::activateScene() when switching away from a scene) correctly sets EC_DOD_EntityInfo::active = false on that scene's entities, but nothing ever read the flag - not the renderer's frustum query, not collision, not ray/cone queries - all of which pull their candidate entities from EC_BroadPhase's spatial index. Deactivating a scene had no actual effect, so its geometry kept rendering (and colliding) right alongside whatever scene was switched to.

Filters inactive entities out of broadPhaseCollisionDetection() itself, since it's the single point every one of those consumers reads from - fixes rendering, gameplay collision, and ray/cone queries in one place rather than patching each consumer separately.