### PR TITLE
Add collision-based impulse physics with SAT+V-Clip narrow phase

### DIFF
--- a/data/scripts/LUA/OnKeyDown.lua
+++ b/data/scripts/LUA/OnKeyDown.lua
@@ -1,4 +1,5 @@
 mouseCaptured = true
+gamePaused = true
 
 function onKeyDown(entity, event)
     local key = event:getKey()
@@ -12,5 +13,13 @@ function onKeyDown(entity, event)
 	if key == "F4" then
 	    mouseCaptured = not mouseCaptured
 	    game:setMouseCaptured(mouseCaptured)
+	end
+	if key == "P" then
+	    gamePaused = not gamePaused
+	    if gamePaused then
+	        game:pauseGame()
+	    else
+	        game:resumeGame()
+	    end
 	end
 end

--- a/data/scripts/XML/EngineConfig.xml
+++ b/data/scripts/XML/EngineConfig.xml
@@ -9,6 +9,26 @@
 	</Collision>
 	<Physics>
 		<TimeStep seconds="0.016"></TimeStep>
+		<!-- How many times Collision+Physics re-run per visual tick, each
+		     against a proportionally smaller timestep (tick/Substeps) -
+		     re-detecting collisions against whatever the previous substep
+		     just integrated instead of once per visual frame. This is the
+		     standard fix modern engines (Box2D v3's TGS Soft, Rapier) use
+		     for stacking stability: a body only marginally destabilized
+		     (e.g. a stack nudged just past its tipping point) otherwise
+		     shows a slow, unrealistic "creep" before visibly toppling,
+		     because gravity/torque integration at one big low-frequency
+		     step per frame tracks the true continuous-time dynamics poorly
+		     near a near-balanced equilibrium. 4 is a common default; 1
+		     disables substepping entirely (original behaviour). -->
+		<Substeps>4</Substeps>
+		<!-- Logs every tick's total system mechanical energy (kinetic +
+		     gravitational potential, summed across every awake dynamic body)
+		     via ECX_Logger, tagged "[ENERGY]". Off by default - meant for
+		     diagnosing solver bugs (a real bug shows as a sustained
+		     increase; kinetic energy alone isn't a useful signal here since
+		     it legitimately grows anytime something is simply falling). -->
+		<Debug><LogEnergy>false</LogEnergy></Debug>
 	</Physics>
 	
 </EngineSettings>

--- a/data/scripts/XML/PhysicsDemo.xml
+++ b/data/scripts/XML/PhysicsDemo.xml
@@ -1,0 +1,354 @@
+<?xml version="1.0"?>
+<Scene>
+	<Entity uid="200" name="physicsdemo_skybox">
+		<Skybox>
+			<HDR>data/assets/Images/Skybox/qwantani_moon_noon_puresky_4k.hdr</HDR>
+		</Skybox>
+	</Entity>
+
+	<!-- Camera faces +Z (Orientation 0,0,0), placed further back and higher
+	     than the original single-column demo to fit the current 6-5-4-3-2
+	     pyramid (bottom row spans x=-6..6, apex at y=10) plus the ball's
+	     roll-in along the ground, all in frame from the first frame. -->
+	<Entity uid="201" name="physicsdemo_camera">
+		<Camera>
+			<FOV>60.0</FOV>
+			<DrawDistance>300.0</DrawDistance>
+		</Camera>
+		<Spatial>
+			<Position>0.0,5.0,-26.0</Position>
+			<Orientation>0.0,0.0,0.0</Orientation>
+		</Spatial>
+		<ScriptComponent>
+			<OnKeyDown filename="data/scripts/LUA/OnKeyDown.lua"/>
+			<OnKeyUp filename="data/scripts/LUA/OnKeyUp.lua"/>
+			<OnKeyHeld filename="data/scripts/LUA/OnKeyHeld.lua"/>
+			<OnMouseMove filename="data/scripts/LUA/onMouseMove.lua"/>
+			<OnUpdate filename="data/scripts/LUA/DebugOverlay.lua"/>
+		</ScriptComponent>
+	</Entity>
+
+	<Entity uid="202" name="physicsdemo_sun">
+		<Light>
+			<Type>Directional</Type>
+			<Direction>0.3,-1.0,0.2,0.0</Direction>
+			<Colour>1.0,1.0,1.0,1.0</Colour>
+			<Intensity>0.8</Intensity>
+			<CastsShadow>true</CastsShadow>
+			<Dynamic>true</Dynamic>
+		</Light>
+	</Entity>
+
+	<!-- Collision-based impulse physics demo (Issue: cube stack + rolling ball).
+	     Floor is a single entity with both the visible plane mesh and a real
+	     (non-zero mask) AABB collider, so cubes/ball actually rest on it -
+	     unlike auto-generated colliders on purely visual geometry elsewhere,
+	     which default to collisionMask=0 and never form gameplay pairs. -->
+	<Entity name="physicsdemo_floor">
+		<Spatial><Position>0.0,0.0,0.0</Position></Spatial>
+		<Transform><Scale>20.0,1.0,20.0</Scale></Transform>
+		<Collider><Type>AABB</Type><Extents>20.0,0.5,20.0</Extents><Center>0.0,-0.5,0.0</Center></Collider>
+		<Gfx>
+			<PBRMaterial>
+				<Albedo>data/assets/Images/Wood_floor/Wood_floor_albedo.png</Albedo>
+				<Normal>data/assets/Images/Wood_floor/Wood_floor_normal-ogl.png</Normal>
+				<Smoothness>data/assets/Images/Wood_floor/Wood_floor_smoothness.png</Smoothness>
+				<Height>data/assets/Images/Wood_floor/Wood_floor_height.png</Height>
+				<Metallic>data/assets/Images/Wood_floor/Wood_floor_metallic.png</Metallic>
+				<AO>data/assets/Images/Wood_floor/Wood_floor_ao.png</AO>
+				<ParallaxScale>0.05</ParallaxScale>
+				<ParallaxBias>0.001</ParallaxBias>
+			</PBRMaterial>
+			<Model>data/assets/models/plane.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+		</Gfx>
+	</Entity>
+
+	<!-- Boundary walls (west/east/north) so a knocked cube or the ball slides
+	     to a stop instead of running off the finite floor - the floor is
+	     40x40 (extents 20), so walls sit at the +-20 edges. Plain axis-aligned
+	     boxes (cube.obj non-uniformly scaled) - no <Orientation> needed, unlike
+	     the rotated-plane walls elsewhere in the codebase. South side (camera's
+	     side) is left open so the view isn't fenced in. -->
+	<Entity name="physicsdemo_wall_west">
+		<Spatial><Position>-20.0,2.0,0.0</Position></Spatial>
+		<Transform><Scale>0.5,2.0,20.0</Scale></Transform>
+		<Collider><Type>AABB</Type><Extents>0.5,2.0,20.0</Extents></Collider>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.55,0.55,0.6,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_wall_east">
+		<Spatial><Position>20.0,2.0,0.0</Position></Spatial>
+		<Transform><Scale>0.5,2.0,20.0</Scale></Transform>
+		<Collider><Type>AABB</Type><Extents>0.5,2.0,20.0</Extents></Collider>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.55,0.55,0.6,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_wall_north">
+		<Spatial><Position>0.0,2.0,20.0</Position></Spatial>
+		<Transform><Scale>20.0,2.0,0.5</Scale></Transform>
+		<Collider><Type>AABB</Type><Extents>20.0,2.0,0.5</Extents></Collider>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.55,0.55,0.6,1.0</Colour>
+		</Gfx>
+	</Entity>
+
+	<!-- South wall at z=-20, closing the one side previously left open.
+	     Sits behind the camera (camera is at z=-18, facing +Z) so it never
+	     enters view - without it, a cube given any residual southward
+	     velocity eventually crosses the floor's edge and falls through the
+	     world entirely, since the floor is a single finite AABB with
+	     nothing past its extents. -->
+	<Entity name="physicsdemo_wall_south">
+		<Spatial><Position>0.0,2.0,-20.0</Position></Spatial>
+		<Transform><Scale>20.0,2.0,0.5</Scale></Transform>
+		<Collider><Type>AABB</Type><Extents>20.0,2.0,0.5</Extents></Collider>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.55,0.55,0.6,1.0</Colour>
+		</Gfx>
+	</Entity>
+
+	<Entity name="physicsdemo_cube_0">
+		<Spatial><Position>-5.0,1.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_1">
+		<Spatial><Position>-3.0,1.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_2">
+		<Spatial><Position>-1.0,1.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_3">
+		<Spatial><Position>1.0,1.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_4">
+		<Spatial><Position>3.0,1.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_5">
+		<Spatial><Position>5.0,1.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_6">
+		<Spatial><Position>-4.0,3.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_7">
+		<Spatial><Position>-2.0,3.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_8">
+		<Spatial><Position>0.0,3.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_9">
+		<Spatial><Position>2.0,3.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_10">
+		<Spatial><Position>4.0,3.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_11">
+		<Spatial><Position>-3.0,5.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_12">
+		<Spatial><Position>-1.0,5.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_13">
+		<Spatial><Position>1.0,5.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_14">
+		<Spatial><Position>3.0,5.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_15">
+		<Spatial><Position>-2.0,7.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_16">
+		<Spatial><Position>0.0,7.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_17">
+		<Spatial><Position>2.0,7.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_18">
+		<Spatial><Position>-1.0,9.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+	<Entity name="physicsdemo_cube_19">
+		<Spatial><Position>1.0,9.0,0.0</Position></Spatial>
+		<Transform><Scale>1.0,1.0,1.0</Scale></Transform>
+		<Collider><Type>OBB</Type><Extents>1.0,1.0,1.0</Extents></Collider>
+		<RigidBody material="Wood"><Sleeping>true</Sleeping></RigidBody>
+		<Gfx>
+			<Model>data/assets/models/cube.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.9,0.6,0.2,1.0</Colour>
+		</Gfx>
+	</Entity>
+
+	<Entity name="physicsdemo_ball">
+		<Spatial><Position>-1.0,1.5,-12.0</Position><Velocity>0.0,4.0,25.0</Velocity></Spatial>
+		<Transform><Scale>1.5,1.5,1.5</Scale></Transform>
+		<Collider><Type>Sphere</Type><Radius>1.5</Radius></Collider>
+		<RigidBody material="Metal"/>
+		<Gfx>
+			<Model>data/assets/models/icosphere.obj</Model>
+			<Shader vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+			<Colour>0.2,0.4,0.9,1.0</Colour>
+		</Gfx>
+	</Entity>
+
+</Scene>

--- a/data/scripts/XML/PhysicsMaterials.xml
+++ b/data/scripts/XML/PhysicsMaterials.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0"?>
+<!-- Named rigid-body presets, loaded once at startup (see TestMode.xml's
+     <PhysicsMaterials> entry) and shared by every scene. Referenced from an
+     entity via <RigidBody material="Alias">...</RigidBody> - any <Mass>/
+     <Restitution>/<Friction>/<StaticFriction>/<RollingFriction>/
+     <LinearDamping>/<AngularDamping> tags authored on that entity still
+     override the preset. Edit this file directly; no rebuild needed, only
+     a relaunch.
+
+     Friction is the KINETIC (sliding) coefficient - it caps the friction
+     impulse once a contact is already slipping. StaticFriction is the
+     separate, normally higher threshold a contact's tangential impulse must
+     exceed before it's allowed to start slipping at all (see
+     EC_PhysicsResolution::accumulateContactPoint) - real materials are
+     almost always harder to START sliding than to KEEP sliding (e.g. wood
+     on wood: ~0.5 static vs ~0.3 kinetic in reality; the values below are
+     tuned for this engine's demo scenes rather than lab measurements, but
+     keep that same static > kinetic relationship). Omitting StaticFriction
+     defaults it to match Friction (no distinct static regime).
+
+     RollingFriction is a SEPARATE, much smaller coefficient resisting
+     ROLLING (not sliding) at a contact - the standard fix (Bullet calls it
+     the same thing) for a box balanced on an edge/corner, or a ball/
+     cylinder, rotating indefinitely with zero tangential slip at its
+     contact point, which ordinary sliding friction can never arrest since
+     rolling-without-slipping satisfies the no-slip condition perfectly.
+     Keep this an order of magnitude below Friction/StaticFriction for
+     EVERY material, not just Metal - it's evaluated fresh against
+     whatever angular velocity exists at the START of each tick, so a
+     coefficient anywhere near sliding-friction scale can fully cancel a
+     genuine gravity-driven topple's angular velocity increment before it
+     has a chance to build up (the impulse needed to arrest a SMALL,
+     just-starting angular velocity is itself small, well within a large
+     coefficient's budget against a loaded contact's normal impulse) -
+     that reads as a large, obviously-unstable overhang crawling over
+     several real seconds instead of toppling in a fraction of one. A
+     genuinely settled near-zero roll only ever needs a tiny nudge to
+     fully stop, so a small coefficient is still enough to kill it -
+     0.005-0.02 across the board here.
+
+     AngularDamping in particular models real energy loss to air resistance
+     and micro-deformation at the contact patch (see EC_PhysicsSystem) -
+     typical range 0.05-0.20/s. Ice is the deliberate low outlier (it
+     genuinely shouldn't settle quickly); everything else sits inside that
+     range so a knocked/rolling body actually comes to rest instead of
+     coasting indefinitely once it reaches a no-slip roll (a state ordinary
+     Coulomb contact friction cannot decelerate on its own). -->
+<Manifest>
+	<PhysicsMaterial alias="Wood">
+		<Mass>1.0</Mass>
+		<Restitution>0.3</Restitution>
+		<Friction>0.6</Friction>
+		<StaticFriction>0.8</StaticFriction>
+		<RollingFriction>0.008</RollingFriction>
+		<LinearDamping>0.05</LinearDamping>
+		<AngularDamping>0.18</AngularDamping>
+	</PhysicsMaterial>
+	<PhysicsMaterial alias="Metal">
+		<Mass>4.0</Mass>
+		<Restitution>0.1</Restitution>
+		<Friction>0.3</Friction>
+		<StaticFriction>0.4</StaticFriction>
+		<RollingFriction>0.015</RollingFriction>
+		<LinearDamping>0.03</LinearDamping>
+		<AngularDamping>0.1</AngularDamping>
+	</PhysicsMaterial>
+	<PhysicsMaterial alias="Rubber">
+		<Mass>0.8</Mass>
+		<Restitution>0.8</Restitution>
+		<Friction>0.75</Friction>
+		<StaticFriction>0.9</StaticFriction>
+		<RollingFriction>0.02</RollingFriction>
+		<LinearDamping>0.06</LinearDamping>
+		<AngularDamping>0.2</AngularDamping>
+	</PhysicsMaterial>
+	<PhysicsMaterial alias="Ice">
+		<Mass>0.9</Mass>
+		<Restitution>0.05</Restitution>
+		<Friction>0.015</Friction>
+		<StaticFriction>0.02</StaticFriction>
+		<RollingFriction>0.005</RollingFriction>
+		<LinearDamping>0.002</LinearDamping>
+		<AngularDamping>0.01</AngularDamping>
+	</PhysicsMaterial>
+	<PhysicsMaterial alias="Stone">
+		<Mass>3.0</Mass>
+		<Restitution>0.15</Restitution>
+		<Friction>0.6</Friction>
+		<StaticFriction>0.8</StaticFriction>
+		<RollingFriction>0.006</RollingFriction>
+		<LinearDamping>0.05</LinearDamping>
+		<AngularDamping>0.15</AngularDamping>
+	</PhysicsMaterial>
+</Manifest>

--- a/data/scripts/XML/Scenes.XML
+++ b/data/scripts/XML/Scenes.XML
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <Scenes>
-	<Scene alias="yard" precache="true" unloadondeactivate="false">data/scripts/XML/LargeYard.xml</Scene>
+	<Scene alias="physics_demo" precache="true" unloadondeactivate="false">data/scripts/XML/PhysicsDemo.xml</Scene>
+	<Scene alias="yard" precache="false" unloadondeactivate="false">data/scripts/XML/LargeYard.xml</Scene>
 	<Scene alias="main" precache="false" unloadondeactivate="false">data/scripts/XML/Scene1.xml</Scene>
 	<Scene alias="streamed" precache="false" unloadondeactivate="true">data/scripts/XML/StreamedZone.xml</Scene>
 </Scenes>

--- a/data/scripts/XML/TestMode.xml
+++ b/data/scripts/XML/TestMode.xml
@@ -5,4 +5,5 @@
 	<Scenes filename="data/scripts/XML/Scenes.xml"></Scenes>
 	<GraphicsSettings filename="data/scripts/XML/GraphicsSetting.xml"/>
 	<UI filename="data/scripts/XML/UI.xml"/>
+	<PhysicsMaterials filename="data/scripts/XML/PhysicsMaterials.xml"/>
 </GameMode>

--- a/src/Components/EC_DOD_Components.h
+++ b/src/Components/EC_DOD_Components.h
@@ -53,6 +53,76 @@ struct EC_DOD_Spatial {
     glm::vec3 right{ 1.0f, 0.0f, 0.0f };
 };
 
+struct EC_DOD_RigidBody {
+    float mass = 1.0f;
+    float restitution = 0.3f;
+    // Kinetic (sliding) friction coefficient - caps the friction impulse
+    // once a contact is actually slipping. See staticFriction below for the
+    // separate, normally-higher threshold that governs whether it starts
+    // slipping in the first place.
+    float friction = 0.5f;
+    // Static friction coefficient - the threshold a contact's tangential
+    // impulse must exceed before it's allowed to slip at all (real
+    // materials almost always have staticFriction >= friction; e.g. wood on
+    // wood is roughly 0.5 static vs 0.3 kinetic - it takes more force to
+    // START a resting object sliding than to KEEP it sliding). Defaults to
+    // matching friction (no distinct static regime) for any material/entity
+    // that doesn't specify one explicitly.
+    float staticFriction = 0.5f;
+    // Rolling resistance coefficient - a small torque, applied AT each
+    // contact point, that opposes ROLLING (not sliding) motion there.
+    // Ordinary Coulomb friction (friction/staticFriction above) only
+    // resists relative TANGENTIAL SLIP at a contact point; a box balanced
+    // on an edge, or a ball/cylinder, can ROTATE about that contact line
+    // with zero slip there at all (identical to a wheel rolling without
+    // slipping), so sliding friction alone can never stop it - the object
+    // just keeps slowly rolling/rocking indefinitely, limited only by the
+    // crude global angularDamping above, which can take many seconds to
+    // arrest a small residual spin. Real materials dissipate this via
+    // contact-patch deformation, modelled here the same way Bullet's
+    // rollingFriction/spinningFriction do: a small angular impulse at the
+    // contact, clamped by this coefficient times the normal impulse. Keep
+    // this an order of magnitude below friction/staticFriction - it's
+    // evaluated fresh against whatever angular velocity exists at the
+    // START of each tick, so a coefficient anywhere near sliding-friction
+    // scale can fully cancel a genuine gravity-driven topple's angular
+    // velocity increment before it has a chance to build up (the impulse
+    // needed to arrest a SMALL, just-starting angular velocity is itself
+    // small, well within a large coefficient's budget against a loaded
+    // contact's normal impulse) - that reads as an obviously-unstable
+    // overhang crawling over several real seconds instead of toppling in
+    // a fraction of one. Defaults to a small nonzero value rather than 0
+    // since 0 reproduces the original (frictionless-rolling) behaviour
+    // exactly.
+    float rollingFriction = 0.01f;
+    // Per-second fractional velocity decay (0 = none), applied every frame
+    // regardless of contact - models drag/internal energy loss. Distinct
+    // from friction, which only acts at a contact point.
+    float linearDamping = 0.01f;
+    float angularDamping = 0.05f;
+    bool isStatic = false;
+    // Runtime state (not authored via XML) - once velocity has been
+    // negligible for long enough, the body is frozen entirely (no gravity,
+    // no integration, no collision resolution) until something with real
+    // velocity hits it and wakes it back up. Without this, resting bodies
+    // keep receiving tiny numerical impulses every frame forever, which
+    // shows up as slow drift/sinking over time even when otherwise at rest.
+    bool isSleeping = false;
+    float sleepTimer = 0.0f;
+};
+
+// Per-body running total of this frame's momentum changes from every source
+// (gravity, every contact point across every colliding pair) - added to but
+// never directly applied to EC_DOD_Spatial until the single, unified apply
+// step (EC_PhysicsResolution::applyAccumulatedImpulses), which adds the
+// total to velocity (linear) then angVelocity (angular) in one place, once
+// per frame. Momentum units throughout (impulse = delta-momentum), so
+// contributions from different sources/contact points are simply additive.
+struct EC_DOD_ImpulseAccumulator {
+    glm::vec3 deltaLinearMomentum{ 0.0f };
+    glm::vec3 deltaAngularMomentum{ 0.0f };
+};
+
 struct EC_DOD_Transform {
     glm::mat4 matrix{ 1.0f };
     glm::vec3 scale{ 1.0f };

--- a/src/Engine/EC_Engine.cpp
+++ b/src/Engine/EC_Engine.cpp
@@ -4,8 +4,10 @@
 #include "Engine/Subsystems/EC_CameraSystem.h"
 #include "Engine/Subsystems/EC_LuaScriptingSystem.h"
 #include "Engine/Subsystems/CollisionSystems/EC_CollisionSystem.h"
+#include "Engine/Subsystems/EC_PhysicsSystem.h"
 #include "TaskManager/EC_PhysicsThreadTask.h"
 #include "TaskManager/EC_ScriptingTask.h"
+#include "xml/XML.h"
 
 EC_Engine::EC_Engine()
 {
@@ -21,6 +23,7 @@ void EC_Engine::init(const std::string& config, EC_Game& game, ECXMessenger& mes
 	m_Systems[(size_t)EC_SystemType::Transform] = std::make_shared<EC_TransformSystem>();
 	m_Systems[(size_t)EC_SystemType::Camera] = std::make_shared<EC_CameraSystem>();
 	m_Systems[(size_t)EC_SystemType::Collision] = std::make_shared<EC_CollisionSystem>();
+	m_Systems[(size_t)EC_SystemType::Physics] = std::make_shared<EC_PhysicsSystem>();
 	m_Systems[(size_t)EC_SystemType::Scripting] = std::make_shared<EC_LuaScriptSystem>();
 
 	for (auto s : m_Systems)
@@ -31,13 +34,34 @@ void EC_Engine::init(const std::string& config, EC_Game& game, ECXMessenger& mes
 		}
 	}
 
+	// Physics reads collision manifolds cached on the pair manager
+	// EC_CollisionSystem's broad/narrow phase populate - wire it once here,
+	// after both systems exist, so it never has to guess at the instance.
+	auto* physicsSystem = static_cast<EC_PhysicsSystem*>(m_Systems[(size_t)EC_SystemType::Physics].get());
+	physicsSystem->setPairManager(
+		&static_cast<EC_CollisionSystem*>(m_Systems[(size_t)EC_SystemType::Collision].get())->getPairManager());
+
+	bool logEnergy = false;
+	int substeps = 1;
+	XML::loadPhysicsDebugSettings(config, logEnergy);
+	XML::loadPhysicsSubstepCount(config, substeps);
+	physicsSystem->setLogEnergy(logEnergy);
+
 	auto task = std::make_shared<EC_PhysicsThreadTask>();
 	task->addGameRef(*m_game);
 	task->addSystem(m_Systems[(size_t)EC_SystemType::Spatial]);
 	task->addSystem(m_Systems[(size_t)EC_SystemType::Transform]);
 	task->addSystem(m_Systems[(size_t)EC_SystemType::Camera]);
 	task->addSystem(m_Systems[(size_t)EC_SystemType::Scripting]);
-	task->addSystem(m_Systems[(size_t)EC_SystemType::Collision]);
+	// Collision + Physics are substepped instead - see
+	// EC_PhysicsThreadTask::setSubstepCount for why (stacking stability:
+	// the same fix Box2D v3/Rapier use for marginal-equilibrium creep).
+	// Must stay in this relative order (Collision before Physics) within
+	// each substep, since Physics consumes the manifolds Collision just
+	// cached that same substep.
+	task->addSubsteppedSystem(m_Systems[(size_t)EC_SystemType::Collision]);
+	task->addSubsteppedSystem(m_Systems[(size_t)EC_SystemType::Physics]);
+	task->setSubstepCount(substeps);
 	task->setTimeStep(1.0f / 60);
 	m_tasks.push_back(task);
 
@@ -75,6 +99,17 @@ void EC_Engine::resume()
 	for (auto t : m_tasks)
 	{
 		t->resume();
+	}
+}
+
+void EC_Engine::stepOnce(float deltaTimeS)
+{
+	for (auto s : m_Systems)
+	{
+		if (s != nullptr)
+		{
+			s->update(deltaTimeS, *m_game);
+		}
 	}
 }
 

--- a/src/Engine/EC_Engine.h
+++ b/src/Engine/EC_Engine.h
@@ -22,6 +22,12 @@ public:
 	void receive(ECXCommand& command) override;
 	void pause();
 	void resume();
+	// Runs every system's update() once, synchronously, on the calling thread -
+	// independent of the threaded task loop and its pause flag. Used to bake a
+	// correct initial transform/camera state (position, scale, view matrix)
+	// before the very first render, since starting paused means the normal
+	// per-tick loop may never run before that first frame is drawn.
+	void stepOnce(float deltaTimeS);
 	void start();
 	void stop();
 	~EC_Engine();

--- a/src/Engine/GameModeSettings.h
+++ b/src/Engine/GameModeSettings.h
@@ -9,4 +9,5 @@ struct GameModeSettings
     std::string scenes_file;
     std::string graphics_settings;
     std::string ui_file;
+    std::string physics_materials_file;
 };

--- a/src/Engine/Subsystems/CollisionSystems/EC_CollisionChecks.cpp
+++ b/src/Engine/Subsystems/CollisionSystems/EC_CollisionChecks.cpp
@@ -1,7 +1,9 @@
 #include "EC_CollisionChecks.h"
+#include "EC_VClip.h"
 
 #include <algorithm>
 #include <cmath>
+#include <vector>
 #include <glm/gtc/matrix_transform.hpp>
 #include <iostream>
 
@@ -90,11 +92,44 @@ bool EC_CollisionChecks::AABBVsAABB(const AABB& aabbA, const glm::vec3& posA, co
 
     const glm::vec3 overlapMin = glm::max(wa.min, wb.min);
     const glm::vec3 overlapMax = glm::min(wa.max, wb.max);
-    const glm::vec3 contact = (overlapMin + overlapMax) * 0.5f;
 
+    // Contact face: the 4 corners of the overlap region in the plane
+    // perpendicular to the collision normal (both boxes are axis-aligned, so
+    // this is exact - no clipping needed, unlike the general OBB case).
+    // Multiple points let a resting/toppled box get counter-torque from all
+    // 4 corners at once, instead of pivoting/rolling around one.
     manifold.contactNormal = normal;
     manifold.penetrationDepth = penetration;
-    manifold.contactPoints = { contact };
+    manifold.contactPoints.clear();
+
+    if (normal.y != 0.0f) {
+        const float y = (overlapMin.y + overlapMax.y) * 0.5f;
+        manifold.contactPoints = {
+            { overlapMin.x, y, overlapMin.z },
+            { overlapMax.x, y, overlapMin.z },
+            { overlapMax.x, y, overlapMax.z },
+            { overlapMin.x, y, overlapMax.z },
+        };
+    }
+    else if (normal.x != 0.0f) {
+        const float x = (overlapMin.x + overlapMax.x) * 0.5f;
+        manifold.contactPoints = {
+            { x, overlapMin.y, overlapMin.z },
+            { x, overlapMax.y, overlapMin.z },
+            { x, overlapMax.y, overlapMax.z },
+            { x, overlapMin.y, overlapMax.z },
+        };
+    }
+    else {
+        const float z = (overlapMin.z + overlapMax.z) * 0.5f;
+        manifold.contactPoints = {
+            { overlapMin.x, overlapMin.y, z },
+            { overlapMax.x, overlapMin.y, z },
+            { overlapMax.x, overlapMax.y, z },
+            { overlapMin.x, overlapMax.y, z },
+        };
+    }
+
     return true;
 
 }
@@ -142,92 +177,95 @@ bool EC_CollisionChecks::OBBVsOBB(const OBB& obbA, const glm::vec3& posA,
         }
     }
 
+    // Track the axis with the smallest penetration across all 15 candidate
+    // axes (standard SAT-derived manifold technique) - that axis becomes the
+    // contact normal. Unlike the boolean-only test, cross-product (edge-edge)
+    // axes must be normalized here so their overlap is a real distance,
+    // comparable against the face axes.
+    float bestOverlap = 1e30f;
+    glm::vec3 bestAxis(0.0f);
+
     // Test axes L = A0, A1, A2
     for (int i = 0; i < 3; i++) {
         ra = obbA.halfExtents[i];
         rb = obbB.halfExtents[0] * absR[i][0] + obbB.halfExtents[1] * absR[i][1] + obbB.halfExtents[2] * absR[i][2];
-        if (glm::abs(t[i]) > ra + rb) {
-            return false;
-        }
+        float overlap = ra + rb - glm::abs(t[i]);
+        if (overlap < 0.0f) return false;
+        if (overlap < bestOverlap) { bestOverlap = overlap; bestAxis = axisA[i]; }
     }
 
     // Test axes L = B0, B1, B2
     for (int i = 0; i < 3; i++) {
         ra = obbA.halfExtents[0] * absR[0][i] + obbA.halfExtents[1] * absR[1][i] + obbA.halfExtents[2] * absR[2][i];
         rb = obbB.halfExtents[i];
-        if (glm::abs(t[0] * R[0][i] + t[1] * R[1][i] + t[2] * R[2][i]) > ra + rb) {
-            return false;
+        float proj = t[0] * R[0][i] + t[1] * R[1][i] + t[2] * R[2][i];
+        float overlap = ra + rb - glm::abs(proj);
+        if (overlap < 0.0f) return false;
+        if (overlap < bestOverlap) { bestOverlap = overlap; bestAxis = axisB[i]; }
+    }
+
+    // Test the 9 edge-edge cross-product axes L = Ai x Bj. For axis-aligned
+    // (or near-axis-aligned) boxes - e.g. a cube resting flat on the floor -
+    // several of these 9 axes are mathematically identical to a face axis
+    // already tested above (cross(X,Y) is the same line as the Z face axis),
+    // just computed through a different formula path with different
+    // floating-point rounding. Without a tie-breaking bias, that rounding
+    // noise can make the "duplicate" edge-edge overlap come out marginally
+    // smaller than the true face overlap and win the naive minimum
+    // comparison - which permanently misclassifies a flat face-face rest as
+    // a single-point edge-edge contact, and a box resting on one point
+    // instead of a stable 4-point face can only pivot/rotate freely about
+    // its own centre rather than being held flat. kEdgeEdgeBias requires an
+    // edge-edge axis to beat the best face overlap by a real margin, not
+    // just numerically, before it's allowed to override a face axis -
+    // standard SAT practice for exactly this degeneracy. Kept deliberately
+    // small: the true floating-point noise between the duplicate axis-
+    // aligned computations is only ~1e-5 to 1e-4 at this engine's unit
+    // scale, so this only needs to be comfortably above that - not so
+    // large that it starts overriding a GENUINE edge/vertex contact for a
+    // meaningfully tilted box (e.g. a corner striking the floor mid-topple)
+    // in favour of an incorrect face axis, which would understate that
+    // corner's true penetration depth and let it sink before the impulse
+    // solver reacts properly.
+    constexpr float kEdgeEdgeBias = 0.001f;
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            glm::vec3 axis = glm::cross(axisA[i], axisB[j]);
+            float len2 = glm::dot(axis, axis);
+            if (len2 < 1e-8f) continue; // near-parallel edges - degenerate, skip
+
+            const float invLen = 1.0f / std::sqrt(len2);
+            axis *= invLen;
+
+            float raGen = 0.0f, rbGen = 0.0f;
+            for (int k = 0; k < 3; k++) {
+                raGen += obbA.halfExtents[k] * glm::abs(glm::dot(axisA[k], axis));
+                rbGen += obbB.halfExtents[k] * glm::abs(glm::dot(axisB[k], axis));
+            }
+            float overlap = raGen + rbGen - glm::abs(glm::dot(T, axis));
+            if (overlap < 0.0f) return false;
+            if (overlap + kEdgeEdgeBias < bestOverlap) {
+                bestOverlap = overlap; bestAxis = axis;
+            }
         }
     }
 
-    // Test axis L = A0 x B0
-    ra = obbA.halfExtents[1] * absR[2][0] + obbA.halfExtents[2] * absR[1][0];
-    rb = obbB.halfExtents[1] * absR[0][2] + obbB.halfExtents[2] * absR[0][1];
-    if (glm::abs(t[2] * R[1][0] - t[1] * R[2][0]) > ra + rb) {
-        return false;
-    }
+    // No separating axis found - OBBs are colliding. bestAxis/bestOverlap now
+    // hold the minimum-penetration axis and depth.
+    glm::vec3 normal = bestAxis;
+    if (glm::dot(T, normal) < 0.0f) normal = -normal; // orient A -> B
 
-    // Test axis L = A0 x B1
-    ra = obbA.halfExtents[1] * absR[2][1] + obbA.halfExtents[2] * absR[1][1];
-    rb = obbB.halfExtents[0] * absR[0][2] + obbB.halfExtents[2] * absR[0][0];
-    if (glm::abs(t[2] * R[1][1] - t[1] * R[2][1]) > ra + rb) {
-        return false;
-    }
+    manifold.contactNormal = normal;
+    manifold.penetrationDepth = bestOverlap;
 
-    // Test axis L = A0 x B2
-    ra = obbA.halfExtents[1] * absR[2][2] + obbA.halfExtents[2] * absR[1][2];
-    rb = obbB.halfExtents[0] * absR[0][1] + obbB.halfExtents[1] * absR[0][0];
-    if (glm::abs(t[2] * R[1][2] - t[1] * R[2][2]) > ra + rb) {
-        return false;
-    }
-
-    // Test axis L = A1 x B0
-    ra = obbA.halfExtents[0] * absR[2][0] + obbA.halfExtents[2] * absR[0][0];
-    rb = obbB.halfExtents[1] * absR[1][2] + obbB.halfExtents[2] * absR[1][1];
-    if (glm::abs(t[0] * R[2][0] - t[2] * R[0][0]) > ra + rb) {
-        return false;
-    }
-
-    // Test axis L = A1 x B1
-    ra = obbA.halfExtents[0] * absR[2][1] + obbA.halfExtents[2] * absR[0][1];
-    rb = obbB.halfExtents[0] * absR[1][2] + obbB.halfExtents[2] * absR[1][0];
-    if (glm::abs(t[0] * R[2][1] - t[2] * R[0][1]) > ra + rb) {
-        return false;
-    }
-
-    // Test axis L = A1 x B2
-    ra = obbA.halfExtents[0] * absR[2][2] + obbA.halfExtents[2] * absR[0][2];
-    rb = obbB.halfExtents[0] * absR[1][1] + obbB.halfExtents[1] * absR[1][0];
-    if (glm::abs(t[0] * R[2][2] - t[2] * R[0][2]) > ra + rb) {
-        return false;
-    }
-
-    // Test axis L = A2 x B0
-    ra = obbA.halfExtents[0] * absR[1][0] + obbA.halfExtents[1] * absR[0][0];
-    rb = obbB.halfExtents[1] * absR[2][2] + obbB.halfExtents[2] * absR[2][1];
-    if (glm::abs(t[1] * R[0][0] - t[0] * R[1][0]) > ra + rb) {
-        return false;
-    }
-
-    // Test axis L = A2 x B1
-    ra = obbA.halfExtents[0] * absR[1][1] + obbA.halfExtents[1] * absR[0][1];
-    rb = obbB.halfExtents[0] * absR[2][2] + obbB.halfExtents[2] * absR[2][0];
-    if (glm::abs(t[1] * R[0][1] - t[0] * R[1][1]) > ra + rb) {
-        return false;
-    }
-
-    // Test axis L = A2 x B2
-    ra = obbA.halfExtents[0] * absR[1][2] + obbA.halfExtents[1] * absR[0][2];
-    rb = obbB.halfExtents[0] * absR[2][1] + obbB.halfExtents[1] * absR[2][0];
-    if (glm::abs(t[1] * R[0][2] - t[0] * R[1][2]) > ra + rb) {
-        return false;
-    }
-
-    // No separating axis found - OBBs are colliding
-
-    manifold.contactNormal = axisA[0];
-    manifold.contactPoints.push_back((centerA + centerB) * 0.5f);
-    manifold.penetrationDepth = 0.1f;
+    // SAT above is only used for the boolean test and penetration depth -
+    // both robust regardless of body size. Which FEATURE pair (face/edge/
+    // vertex on each box) is actually touching is picked independently here,
+    // by walking to the true closest features via local Voronoi-region
+    // classification rather than SAT's raw numeric overlap comparison, which
+    // misclassifies "edge-edge" whenever body sizes are grossly mismatched
+    // (e.g. a cube vs a room-sized floor slab) - see EC_VClip.h for why.
+    EC_VClip::generateContactPoints(obbA, posA, obbB, posB, normal, bestOverlap, manifold);
 
     return true;
 }

--- a/src/Engine/Subsystems/CollisionSystems/EC_CollisionSystem.h
+++ b/src/Engine/Subsystems/CollisionSystems/EC_CollisionSystem.h
@@ -17,6 +17,11 @@ class EC_CollisionSystem
 	// Inherited via EC_System
 	virtual void init(ECXMessenger& messenger, EC_Game& game) override;
 	virtual void update(const float& deltaTimeS, EC_Game& game) override;
+
+	// Exposes the same pair manager broad/narrow phase populate, so
+	// EC_PhysicsSystem can be wired to it once at startup and iterate the
+	// cached collision manifolds after this system's update() has run.
+	EC_PairManager& getPairManager() { return m_PairManager; }
 private:
 	std::unique_ptr<EC_BroadPhase> m_BroadPhase;
 	std::unique_ptr<EC_NarrowPhase> m_NarrowPhase;

--- a/src/Engine/Subsystems/CollisionSystems/EC_NarrowPhase.cpp
+++ b/src/Engine/Subsystems/CollisionSystems/EC_NarrowPhase.cpp
@@ -3,6 +3,7 @@
 #include "Entity/EC_DOD_EntityManager.h"
 #include "Components/EC_DOD_Components.h"
 #include "EC_CollisionChecks.h"
+#include "EC_PhysicsResolution.h"
 #include "Messaging/ECXEvent.h"
 #include "Messaging/ECXMessenger.h"
 #include <functional>
@@ -13,6 +14,11 @@ void EC_NarrowPhase::init(ECXMessenger& messenger)
     initCollisionDispatchTable();  // Add this line
 }
 
+// Purely geometric: detects overlap and caches the resulting manifold
+// (contact points, normal, penetration depth) on the pair for the physics
+// system to consume later this tick. Computes no impulses/forces at all -
+// that's entirely the physics system's job (see EC_PhysicsSystem), which
+// iterates the same pairs afterward via EC_PairManager::getAllPairs().
 void EC_NarrowPhase::narrowPhaseCollisionDetection()
 {
     // For each pair in the pair manager, perform narrow phase collision detection
@@ -53,14 +59,20 @@ void EC_NarrowPhase::narrowPhaseCollisionDetection()
         // Update pair collision status
         pair.m_Colliding = collisionDetected;
 
-        // If collision detected, store contact points
+        // If collision detected, cache the geometric manifold on the pair -
+        // contact points, normal, and penetration depth - for the physics
+        // system to read afterward. No eligibility/force decisions here.
         if (collisionDetected)
         {
             pair.m_CollisionPoints = manifold.contactPoints;
+            pair.m_ContactNormal = manifold.contactNormal;
+            pair.m_PenetrationDepth = manifold.penetrationDepth;
         }
         else
         {
             pair.m_CollisionPoints.clear();
+            pair.m_ContactNormal = glm::vec3(0.0f);
+            pair.m_PenetrationDepth = 0.0f;
         }
     }
 }
@@ -94,9 +106,14 @@ void EC_NarrowPhase::initCollisionDispatchTable()
         // Sphere vs AABB
         {makeKey(EC_DOD_Collider::Type::Sphere, EC_DOD_Collider::Type::AABB),
             [](auto& a, auto& sa, auto& b, auto& sb, auto& m) {
-                return EC_CollisionChecks::SphereVsAABB(
+                bool hit = EC_CollisionChecks::SphereVsAABB(
                     Sphere{a.center, a.radius}, sa.position,
                     AABB{b.center - b.extents, b.center + b.extents}, sb.position, m);
+                // SphereVsAABB's normal points toward the sphere (param A here); flip
+                // so contactNormal consistently points body_A -> body_B like every
+                // other dispatch entry.
+                if (hit) m.contactNormal = -m.contactNormal;
+                return hit;
             }},
 
         // AABB vs Sphere (swap parameters)
@@ -121,15 +138,43 @@ void EC_NarrowPhase::initCollisionDispatchTable()
                     OBB{b.center, b.extents, orientB}, sb.position, m);
             }},
 
+        // OBB vs AABB (AABB never rotates, so treat it as an identity-oriented
+        // OBB and reuse the same SAT manifold code - OBBVsOBB already
+        // self-orients its normal body_A -> body_B, no extra sign-flip needed
+        // here unlike the Sphere pairs above).
+        {makeKey(EC_DOD_Collider::Type::OBB, EC_DOD_Collider::Type::AABB),
+            [](auto& a, auto& sa, auto& b, auto& sb, auto& m) {
+                glm::mat3 orientA = glm::mat3(glm::normalize(sa.right),
+                                             glm::normalize(sa.up),
+                                             glm::normalize(sa.direction));
+                return EC_CollisionChecks::OBBVsOBB(
+                    OBB{a.center, a.extents, orientA}, sa.position,
+                    OBB{b.center, b.extents, glm::mat3(1.0f)}, sb.position, m);
+            }},
+
+        // AABB vs OBB (swap parameters)
+        {makeKey(EC_DOD_Collider::Type::AABB, EC_DOD_Collider::Type::OBB),
+            [](auto& a, auto& sa, auto& b, auto& sb, auto& m) {
+                glm::mat3 orientB = glm::mat3(glm::normalize(sb.right),
+                                             glm::normalize(sb.up),
+                                             glm::normalize(sb.direction));
+                return EC_CollisionChecks::OBBVsOBB(
+                    OBB{a.center, a.extents, glm::mat3(1.0f)}, sa.position,
+                    OBB{b.center, b.extents, orientB}, sb.position, m);
+            }},
+
         // Sphere vs OBB
         {makeKey(EC_DOD_Collider::Type::Sphere, EC_DOD_Collider::Type::OBB),
             [](auto& a, auto& sa, auto& b, auto& sb, auto& m) {
                 glm::mat3 orientB = glm::mat3(glm::normalize(sb.right),
                                              glm::normalize(sb.up),
                                              glm::normalize(sb.direction));
-                return EC_CollisionChecks::SphereVsOBB(
+                bool hit = EC_CollisionChecks::SphereVsOBB(
                     Sphere{a.center, a.radius}, sa.position,
                     OBB{b.center, b.extents, orientB}, sb.position, m);
+                // Same fix as Sphere vs AABB above: flip to body_A -> body_B convention.
+                if (hit) m.contactNormal = -m.contactNormal;
+                return hit;
             }},
 
         // OBB vs Sphere (swap parameters)
@@ -201,6 +246,13 @@ void EC_NarrowPhase::handleCollisionStateChange(
     // Collision ended
     if (pair.m_Colliding && !collisionDetected)
     {
+        // Either side may have been sleeping while resting against the
+        // other (e.g. a cube asleep on top of one that just got knocked
+        // away) - losing that contact needs to wake it back up rather than
+        // leaving it frozen mid-air with nothing left holding it up.
+        EC_PhysicsResolution::wakeIfSleeping(pair.body_A);
+        EC_PhysicsResolution::wakeIfSleeping(pair.body_B);
+
         ECXEvent msg;
         msg.type = ECXEventType::CollisionEndEvent;
         msg.args[0] = pair.body_A;

--- a/src/Engine/Subsystems/CollisionSystems/EC_PairManager.cpp
+++ b/src/Engine/Subsystems/CollisionSystems/EC_PairManager.cpp
@@ -66,3 +66,8 @@ EC_CollisionPair& EC_PairManager::getNextPair()
 	return s_Pairs[s_CurrentPairIndex++];
 }
 
+std::vector<EC_CollisionPair>& EC_PairManager::getAllPairs()
+{
+	return s_Pairs;
+}
+

--- a/src/Engine/Subsystems/CollisionSystems/EC_PairManager.h
+++ b/src/Engine/Subsystems/CollisionSystems/EC_PairManager.h
@@ -4,12 +4,40 @@
 #include <memory>
 #include <cstddef>
 
+// One contact point's accumulated impulse, persisted across ticks while the
+// pair keeps colliding - "warm starting". Physics resolution seeds each
+// tick's solve from last tick's converged total instead of starting at zero
+// every time, which is what lets a persistent contact (e.g. a box resting
+// or tumbling on the floor across many consecutive ticks) actually converge
+// tick-to-tick instead of re-deriving the same answer from scratch and
+// re-introducing solver noise every frame - standard technique in every
+// production physics engine (Box2D, Bullet, etc).
+struct EC_ContactImpulseCache
+{
+	glm::vec3 point{ 0.0f };
+	float normalImpulse = 0.0f;
+	float tangentImpulse = 0.0f;
+};
+
 struct EC_CollisionPair
 {
 	uint32_t body_A;
 	uint32_t body_B;
 	bool m_Colliding;
 	std::vector<glm::vec3> m_CollisionPoints;
+	// Geometric manifold data cached by collision detection (EC_NarrowPhase)
+	// for the physics system to consume later this tick - collision
+	// resolution only ever writes these, it never computes forces/impulses
+	// from them itself.
+	glm::vec3 m_ContactNormal{ 0.0f };
+	float m_PenetrationDepth = 0.0f;
+	// Warm-start cache, one entry per contact point, matched frame-to-frame
+	// by closest position (see EC_PhysicsResolution::accumulateImpulses) -
+	// owned and updated entirely by the physics system. Naturally cleared
+	// when the pair itself is destroyed (EC_PairManager::update() erases
+	// non-colliding pairs), so no separate cleanup is needed when contact
+	// genuinely ends.
+	std::vector<EC_ContactImpulseCache> m_ContactCache;
 	EC_CollisionPair() :body_A(0), body_B(0), m_Colliding(false) {}
 };
 class EC_PairManager
@@ -21,6 +49,12 @@ public:
 	void update();
 	bool hasPairs();
 	EC_CollisionPair& getNextPair();
+	// Mutable view of every tracked pair, independent of the hasPairs()/
+	// getNextPair() consuming cursor - lets the physics system iterate all
+	// currently-colliding pairs after collision detection has already
+	// drained the cursor this tick. Mutable (not just read-only) so physics
+	// can update each pair's m_ContactCache for next tick's warm start.
+	static std::vector<EC_CollisionPair>& getAllPairs();
 private:
 	static std::vector<EC_CollisionPair> s_Pairs;
 	static size_t s_CurrentPairIndex;

--- a/src/Engine/Subsystems/CollisionSystems/EC_PhysicsResolution.cpp
+++ b/src/Engine/Subsystems/CollisionSystems/EC_PhysicsResolution.cpp
@@ -1,0 +1,546 @@
+#include "EC_PhysicsResolution.h"
+#include "Entity/EC_DOD_EntityManager.h"
+#include "Components/EC_DOD_Components.h"
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+    constexpr float kEpsilon = 1e-6f;
+    constexpr float kPenetrationSlop = 0.01f;
+    // Below this closing speed, treat the impact as inelastic (0 restitution)
+    // regardless of the bodies' material restitution. Without this, a resting
+    // object gets a fractional bounce-back every single frame from the tiny
+    // closing velocity gravity itself adds before collision resolution runs -
+    // perpetual micro-bounce that either jitters in place or, if the bounce
+    // undershoots what gravity re-adds next frame, nets out as slow sinking.
+    // Standard technique (Box2D calls this b2_velocityThreshold). Set high
+    // enough to also cover a tumbling box's corner/edge striking the floor
+    // mid-settle - that should read as an inelastic "thud" that kills the
+    // tumble, not a bounce. Measured empirically: a cube ejected from a
+    // collapsing stack can spin at 4-5 rad/s, so a corner (roughly half the
+    // face diagonal from center, ~0.7-1.0 units) strikes the floor at
+    // 3-5 m/s purely from rotation, on top of whatever it's translating at -
+    // a 2.0 threshold let every one of those corner strikes bounce at 0.3
+    // restitution instead of going inelastic, which sustains the tumble
+    // indefinitely instead of killing it. Genuinely hard impacts (the ball
+    // hitting the stack, ~5+ m/s of real linear closing speed) are still
+    // well above this and bounce normally.
+    constexpr float kRestitutionVelocityThreshold = 6.0f;
+    // Fraction of excess penetration (beyond slop) that correctPosition
+    // removes immediately, once per pair per tick. 1.0 would fully close
+    // the gap in one shot but tends to overshoot/pop when several pairs on
+    // the same body disagree about direction; 0.2-0.8 is the standard
+    // range, correcting fully within a handful of ticks without visible
+    // popping.
+    constexpr float kPositionCorrectionPercent = 0.4f;
+
+    struct ResolvedBody
+    {
+        float invMass = 0.0f;
+        float restitution = 0.3f;
+        float friction = 0.5f;
+        float staticFriction = 0.5f;
+        float rollingFriction = 0.05f;
+        bool isStatic = true;
+        glm::mat3 invInertiaWorld{ 0.0f };
+    };
+
+    ResolvedBody resolveBody(EC_DOD_EntityManager& manager, EntityID entity)
+    {
+        ResolvedBody body;
+        if (manager.hasComponent<EC_DOD_RigidBody>(entity)) {
+            const auto& rb = manager.getComponent<EC_DOD_RigidBody>(entity);
+            body.isStatic = rb.isStatic;
+            body.restitution = rb.restitution;
+            body.friction = rb.friction;
+            body.staticFriction = rb.staticFriction;
+            body.rollingFriction = rb.rollingFriction;
+            body.invMass = (rb.isStatic || rb.mass <= kEpsilon) ? 0.0f : (1.0f / rb.mass);
+            if (body.invMass > 0.0f) {
+                body.invInertiaWorld = EC_PhysicsResolution::computeInvInertiaWorld(entity, rb.mass);
+            }
+        }
+        return body;
+    }
+
+    // Adds a linear+angular momentum contribution to entity's accumulator, if
+    // it has one (entities without EC_DOD_RigidBody, e.g. static scene
+    // geometry, silently receive nothing - correct, they never move).
+    void addMomentum(EC_DOD_EntityManager& manager, EntityID entity,
+        const glm::vec3& linearDelta, const glm::vec3& angularDelta)
+    {
+        if (!manager.hasComponent<EC_DOD_ImpulseAccumulator>(entity)) return;
+        auto& accum = manager.getComponent<EC_DOD_ImpulseAccumulator>(entity);
+        accum.deltaLinearMomentum += linearDelta;
+        accum.deltaAngularMomentum += angularDelta;
+    }
+
+    // A body's velocity/angular velocity as resolution works through one
+    // pair's manifold this tick - starts as a copy of the real
+    // EC_DOD_Spatial values and is updated after every contact point, but
+    // never written back to EC_DOD_Spatial itself (that still only happens
+    // once, in EC_PhysicsSystem's apply step).
+    struct LocalVelocity
+    {
+        glm::vec3 velocity;
+        glm::vec3 angVelocity;
+    };
+
+    glm::vec3 velocityAtPoint(const LocalVelocity& local, const glm::vec3& r)
+    {
+        return local.velocity + glm::cross(local.angVelocity, r);
+    }
+
+    // Applies impulse to both bodies' running local velocities (so the next
+    // contact point in this same manifold sees the effect) and, in
+    // parallel, adds the same contribution to each body's real
+    // EC_DOD_ImpulseAccumulator for EC_PhysicsSystem to apply once later.
+    void applyImpulse(EC_DOD_EntityManager& manager, EntityID a, EntityID b,
+        const ResolvedBody& bodyA, const ResolvedBody& bodyB,
+        const glm::vec3& rA, const glm::vec3& rB, const glm::vec3& impulse,
+        LocalVelocity& localA, LocalVelocity& localB)
+    {
+        const glm::vec3 angularA = -glm::cross(rA, impulse);
+        const glm::vec3 angularB = glm::cross(rB, impulse);
+
+        addMomentum(manager, a, -impulse, angularA);
+        addMomentum(manager, b, impulse, angularB);
+
+        localA.velocity += -impulse * bodyA.invMass;
+        localA.angVelocity += bodyA.invInertiaWorld * angularA;
+        localB.velocity += impulse * bodyB.invMass;
+        localB.angVelocity += bodyB.invInertiaWorld * angularB;
+    }
+
+    // Computes the normal + friction impulse at one contact point, using
+    // the standard accumulated-impulse (warm-started) pattern: cache.
+    // normalImpulse already holds the running total from every earlier
+    // iteration this tick, PLUS whatever carried over from last tick (see
+    // accumulateImpulses) - this computes the INCREMENTAL correction still
+    // needed given the current (already-updated) local velocity, adds it
+    // to that running total, clamps the TOTAL (not just the increment) to
+    // stay non-negative, and applies only the resulting delta. That's what
+    // makes a persistent contact (a resting or tumbling box) converge
+    // smoothly tick-to-tick instead of re-deriving - and re-injecting
+    // solver noise from - a fresh answer every single frame.
+    //
+    // Contact points within the same manifold are resolved sequentially
+    // (Gauss-Seidel) against localA/localB, which the caller updates in
+    // place after every point - a resting/toppled box against a flat
+    // surface has up to 4 points (see AABBVsAABB/OBBVsOBB), and solving
+    // them independently would inject spurious net torque instead of
+    // cancelling it. This is still entirely local to this one pair/
+    // manifold - it never touches the real EC_DOD_Spatial, and cross-pair
+    // ordering stays whatever order EC_PhysicsSystem's step 1 happens to
+    // iterate pairs in.
+    void accumulateContactPoint(EC_DOD_EntityManager& manager, EntityID a, EntityID b,
+        const glm::vec3& posA, const glm::vec3& posB,
+        LocalVelocity& localA, LocalVelocity& localB,
+        const ResolvedBody& bodyA, const ResolvedBody& bodyB,
+        const glm::vec3& contactPoint, const glm::vec3& normal, float invMassSum,
+        EC_ContactImpulseCache& cache)
+    {
+        const glm::vec3 rA = contactPoint - posA;
+        const glm::vec3 rB = contactPoint - posB;
+
+        // Penetration depth is resolved entirely by correctPosition (a
+        // direct, unbounded position correction run once per pair after
+        // velocity resolution) - NOT by a velocity-space bias here.
+        // Combining a Baumgarte bias with a direct position correction
+        // double-corrects: the position fix removes the overlap, but the
+        // bias-driven separating velocity it also added is still there and
+        // keeps pushing the body apart on top of that, which reads as
+        // bouncing/skittering. This impulse now only ever cancels real
+        // closing velocity (with restitution), same as it would for a
+        // pair that isn't penetrating at all.
+        const glm::vec3 relativeVelocity = velocityAtPoint(localB, rB) - velocityAtPoint(localA, rA);
+        const float velAlongNormal = glm::dot(relativeVelocity, normal);
+
+        const glm::vec3 raCrossN = glm::cross(rA, normal);
+        const glm::vec3 rbCrossN = glm::cross(rB, normal);
+        const float angularTermA = glm::dot(glm::cross(bodyA.invInertiaWorld * raCrossN, rA), normal);
+        const float angularTermB = glm::dot(glm::cross(bodyB.invInertiaWorld * rbCrossN, rB), normal);
+        const float denom = invMassSum + angularTermA + angularTermB;
+        if (denom <= kEpsilon) {
+            return;
+        }
+
+        // --- Normal impulse: accumulated/clamped pattern, seeded from
+        // cache.normalImpulse (warm start). ---
+        const float restitution = (-velAlongNormal > kRestitutionVelocityThreshold)
+            ? std::min(bodyA.restitution, bodyB.restitution)
+            : 0.0f;
+        const float lambda = -(1.0f + restitution) * velAlongNormal / denom;
+        const float newNormalTotal = std::max(0.0f, cache.normalImpulse + lambda);
+        const float deltaNormal = newNormalTotal - cache.normalImpulse;
+        cache.normalImpulse = newNormalTotal;
+
+        if (std::abs(deltaNormal) > kEpsilon) {
+            applyImpulse(manager, a, b, bodyA, bodyB, rA, rB, deltaNormal * normal, localA, localB);
+        }
+
+        if (newNormalTotal <= 0.0f) {
+            return; // nothing to grip for friction either
+        }
+
+        // --- Rolling resistance: a small torque at this contact point
+        // opposing RELATIVE ANGULAR velocity (rolling), independent of
+        // whether there's any tangential SLIP here at all - a pure rolling
+        // contact (a box balanced on an edge, a ball on the floor) has
+        // ZERO relative tangential velocity by definition, which is
+        // exactly the case ordinary sliding/static friction below can
+        // never resist (that's the whole point of rollingFriction - see
+        // EC_DOD_RigidBody). Computed BEFORE the tangential-slip early
+        // return above would otherwise skip it entirely. Applied as a
+        // pure angular impulse - no lever arm, no linear reaction -
+        // since rolling resistance is a torque effect, not a force at a
+        // point; not warm-started across ticks, same as tangential
+        // friction (recomputed fresh from current velocity each call).
+        {
+            const glm::vec3 relativeAngVel = localB.angVelocity - localA.angVelocity;
+            const float relativeAngSpeed2 = glm::dot(relativeAngVel, relativeAngVel);
+            if (relativeAngSpeed2 > kEpsilon) {
+                const float relativeAngSpeed = std::sqrt(relativeAngSpeed2);
+                const glm::vec3 rollAxis = relativeAngVel / relativeAngSpeed;
+                const float rollingCoefficient = std::sqrt(bodyA.rollingFriction * bodyB.rollingFriction);
+                const float maxRollingImpulse = rollingCoefficient * newNormalTotal;
+
+                const float angularDenomA = glm::dot(bodyA.invInertiaWorld * rollAxis, rollAxis);
+                const float angularDenomB = glm::dot(bodyB.invInertiaWorld * rollAxis, rollAxis);
+                const float rollDenom = angularDenomA + angularDenomB;
+                if (rollDenom > kEpsilon) {
+                    const float fullStopImpulse = relativeAngSpeed / rollDenom;
+                    const float rollingImpulseMag = std::min(fullStopImpulse, maxRollingImpulse);
+                    const glm::vec3 rollingAngularImpulse = -rollingImpulseMag * rollAxis;
+
+                    localA.angVelocity -= bodyA.invInertiaWorld * rollingAngularImpulse;
+                    localB.angVelocity += bodyB.invInertiaWorld * rollingAngularImpulse;
+                    addMomentum(manager, a, glm::vec3(0.0f), -rollingAngularImpulse);
+                    addMomentum(manager, b, glm::vec3(0.0f), rollingAngularImpulse);
+                }
+            }
+        }
+
+        // --- Friction: Coulomb friction clamped to this point's total
+        // normal impulse - re-reads relative velocity now that the normal
+        // impulse above has already updated localA/localB. Not
+        // warm-started across ticks (see header comment) - always starts
+        // this tick's accumulation from zero.
+        const glm::vec3 relativeVelocityAfterNormal = velocityAtPoint(localB, rB) - velocityAtPoint(localA, rA);
+        glm::vec3 tangent = relativeVelocityAfterNormal - normal * glm::dot(relativeVelocityAfterNormal, normal);
+        const float tangentLen2 = glm::dot(tangent, tangent);
+        if (tangentLen2 <= kEpsilon) {
+            return;
+        }
+        tangent /= std::sqrt(tangentLen2);
+
+        const glm::vec3 raCrossT = glm::cross(rA, tangent);
+        const glm::vec3 rbCrossT = glm::cross(rB, tangent);
+        const float angularTermTA = glm::dot(glm::cross(bodyA.invInertiaWorld * raCrossT, rA), tangent);
+        const float angularTermTB = glm::dot(glm::cross(bodyB.invInertiaWorld * rbCrossT, rB), tangent);
+        const float denomT = invMassSum + angularTermTA + angularTermTB;
+        if (denomT <= kEpsilon) {
+            return;
+        }
+
+        // lambdaT is the impulse that would fully cancel tangential
+        // velocity this sub-step - i.e. "stick" the contact completely.
+        // Static vs kinetic Coulomb friction: if that stick impulse (added
+        // to whatever's already accumulated) fits within the STATIC cone,
+        // apply it in full - the contact holds, zero slip results. Only
+        // once it exceeds that (real, usually higher) threshold does it
+        // clamp down to the KINETIC cone instead, leaving the contact
+        // genuinely sliding under a capped friction force. Using a single
+        // coefficient for both would make a resting stack just as easy to
+        // start sliding as to keep sliding, understating how much a real
+        // contact resists breaking static grip in the first place.
+        const float lambdaT = -glm::dot(relativeVelocityAfterNormal, tangent) / denomT;
+        const float staticCoefficient = std::sqrt(bodyA.staticFriction * bodyB.staticFriction);
+        const float kineticCoefficient = std::sqrt(bodyA.friction * bodyB.friction);
+        const float maxStaticFriction = staticCoefficient * newNormalTotal;
+        const float maxKineticFriction = kineticCoefficient * newNormalTotal;
+        const float unclampedTangentTotal = cache.tangentImpulse + lambdaT;
+        const float newTangentTotal = (std::abs(unclampedTangentTotal) <= maxStaticFriction)
+            ? unclampedTangentTotal
+            : std::clamp(unclampedTangentTotal, -maxKineticFriction, maxKineticFriction);
+        const float deltaTangent = newTangentTotal - cache.tangentImpulse;
+        cache.tangentImpulse = newTangentTotal;
+
+        if (std::abs(deltaTangent) > kEpsilon) {
+            applyImpulse(manager, a, b, bodyA, bodyB, rA, rB, deltaTangent * tangent, localA, localB);
+        }
+    }
+}
+
+namespace EC_PhysicsResolution
+{
+    glm::mat3 computeInvInertiaWorld(EntityID entity, float mass)
+    {
+        auto& manager = EC_DOD_EntityManager::getInstance();
+        if (!manager.hasComponent<EC_DOD_Collider>(entity)) return glm::mat3(0.0f);
+        const auto& collider = manager.getComponent<EC_DOD_Collider>(entity);
+
+        glm::vec3 invInertiaDiag(0.0f);
+        glm::mat3 orientation(1.0f);
+
+        if (collider.type == EC_DOD_Collider::Type::Sphere)
+        {
+            const float r = collider.radius;
+            const float I = (2.0f / 5.0f) * mass * r * r;
+            invInertiaDiag = glm::vec3(I > kEpsilon ? 1.0f / I : 0.0f);
+        }
+        else if (collider.type == EC_DOD_Collider::Type::AABB || collider.type == EC_DOD_Collider::Type::OBB)
+        {
+            const glm::vec3 full = collider.extents * 2.0f;
+            const glm::vec3 I(
+                (1.0f / 12.0f) * mass * (full.y * full.y + full.z * full.z),
+                (1.0f / 12.0f) * mass * (full.x * full.x + full.z * full.z),
+                (1.0f / 12.0f) * mass * (full.x * full.x + full.y * full.y));
+            invInertiaDiag = glm::vec3(
+                I.x > kEpsilon ? 1.0f / I.x : 0.0f,
+                I.y > kEpsilon ? 1.0f / I.y : 0.0f,
+                I.z > kEpsilon ? 1.0f / I.z : 0.0f);
+
+            if (collider.type == EC_DOD_Collider::Type::OBB && manager.hasComponent<EC_DOD_Spatial>(entity))
+            {
+                const auto& spatial = manager.getComponent<EC_DOD_Spatial>(entity);
+                orientation = glm::mat3(glm::normalize(spatial.right), glm::normalize(spatial.up), glm::normalize(spatial.direction));
+            }
+        }
+        else
+        {
+            return glm::mat3(0.0f);
+        }
+
+        glm::mat3 invInertiaLocal(0.0f);
+        invInertiaLocal[0][0] = invInertiaDiag.x;
+        invInertiaLocal[1][1] = invInertiaDiag.y;
+        invInertiaLocal[2][2] = invInertiaDiag.z;
+
+        return orientation * invInertiaLocal * glm::transpose(orientation);
+    }
+
+    void warmStartPair(EntityID a, EntityID b, const CollisionManifold& manifold,
+        std::vector<EC_ContactImpulseCache>& contactCache)
+    {
+        if (glm::dot(manifold.contactNormal, manifold.contactNormal) < kEpsilon) { contactCache.clear(); return; }
+        if (manifold.contactPoints.empty()) { contactCache.clear(); return; }
+
+        auto& manager = EC_DOD_EntityManager::getInstance();
+        if (!manager.hasComponent<EC_DOD_Spatial>(a) || !manager.hasComponent<EC_DOD_Spatial>(b)) {
+            contactCache.clear();
+            return;
+        }
+        const auto& spatialA = manager.getComponent<EC_DOD_Spatial>(a);
+        const auto& spatialB = manager.getComponent<EC_DOD_Spatial>(b);
+
+        // Match this tick's contact points to last tick's cache by closest
+        // position (within a small radius) so each point's accumulated
+        // normal impulse carries over. Unmatched points (a genuinely new
+        // contact) start at zero, same as with no warm starting at all.
+        //
+        // One-to-one: each OLD cache entry can be claimed by at most one
+        // NEW point (usedOld tracks that). Without this, a manifold that
+        // grows point count tick-to-tick (e.g. a box settling face-flat,
+        // 1 point -> 2 -> 4 as it rocks down) can have several new points
+        // all fall within the matching radius of the SAME old point, each
+        // independently inheriting its full cached impulse - duplicating a
+        // single real impulse 2x/3x/4x and injecting real, non-physical
+        // energy into the system on exactly the settling transitions this
+        // was meant to smooth out.
+        std::vector<EC_ContactImpulseCache> newCache(manifold.contactPoints.size());
+        std::vector<bool> usedOld(contactCache.size(), false);
+        for (size_t i = 0; i < manifold.contactPoints.size(); i++) {
+            newCache[i].point = manifold.contactPoints[i];
+            float bestDist2 = 0.25f; // 0.5 unit matching radius, squared
+            int bestMatch = -1;
+            for (size_t j = 0; j < contactCache.size(); j++) {
+                if (usedOld[j]) continue;
+                const glm::vec3 diff = manifold.contactPoints[i] - contactCache[j].point;
+                const float d2 = glm::dot(diff, diff);
+                if (d2 < bestDist2) { bestDist2 = d2; bestMatch = static_cast<int>(j); }
+            }
+            if (bestMatch >= 0) {
+                newCache[i].normalImpulse = contactCache[bestMatch].normalImpulse;
+                usedOld[bestMatch] = true;
+            }
+        }
+
+        // Apply every matched point's carried-over normal impulse directly
+        // to the real EC_DOD_ImpulseAccumulator, once, so every
+        // previewVelocity call this tick (across every later solver pass)
+        // reflects it as this tick's starting guess.
+        for (size_t i = 0; i < newCache.size(); i++) {
+            if (newCache[i].normalImpulse <= kEpsilon) continue;
+            const glm::vec3 rA = manifold.contactPoints[i] - spatialA.position;
+            const glm::vec3 rB = manifold.contactPoints[i] - spatialB.position;
+            const glm::vec3 impulse = newCache[i].normalImpulse * manifold.contactNormal;
+            addMomentum(manager, a, -impulse, -glm::cross(rA, impulse));
+            addMomentum(manager, b, impulse, glm::cross(rB, impulse));
+        }
+
+        contactCache = std::move(newCache);
+    }
+
+    void accumulateImpulses(EntityID a, EntityID b, const CollisionManifold& manifold,
+        const glm::vec3& velA, const glm::vec3& angVelA,
+        const glm::vec3& velB, const glm::vec3& angVelB,
+        std::vector<EC_ContactImpulseCache>& contactCache)
+    {
+        if (glm::dot(manifold.contactNormal, manifold.contactNormal) < kEpsilon) return;
+        if (manifold.contactPoints.empty()) return;
+        if (contactCache.size() != manifold.contactPoints.size()) return; // warmStartPair wasn't called for this tick's manifold
+
+        auto& manager = EC_DOD_EntityManager::getInstance();
+        ResolvedBody bodyA = resolveBody(manager, a);
+        ResolvedBody bodyB = resolveBody(manager, b);
+
+        const float invMassSum = bodyA.invMass + bodyB.invMass;
+        if (invMassSum <= kEpsilon) return;
+
+        if (!manager.hasComponent<EC_DOD_Spatial>(a) || !manager.hasComponent<EC_DOD_Spatial>(b)) return;
+
+        const auto& spatialA = manager.getComponent<EC_DOD_Spatial>(a);
+        const auto& spatialB = manager.getComponent<EC_DOD_Spatial>(b);
+
+        LocalVelocity localA{ velA, angVelA };
+        LocalVelocity localB{ velB, angVelB };
+
+        // Revisit this pair's own manifold several times per call (standard
+        // sequential-impulse practice - Box2D/Bullet default to ~4-8), not
+        // just once. A single pass measured empirically as insufficient:
+        // at a single grazing corner mid-topple, the normal impulse from
+        // one pass often doesn't yet reflect the body's full weight, so
+        // friction's budget (mu * that impulse) comes up short and real
+        // slip persists that a second/third pass - seeing the already-
+        // improved local velocity - converges away.
+        constexpr int kManifoldIterations = 4;
+        for (int iteration = 0; iteration < kManifoldIterations; iteration++) {
+            for (size_t i = 0; i < manifold.contactPoints.size(); i++) {
+                accumulateContactPoint(manager, a, b, spatialA.position, spatialB.position,
+                    localA, localB, bodyA, bodyB,
+                    manifold.contactPoints[i], manifold.contactNormal, invMassSum,
+                    contactCache[i]);
+            }
+        }
+    }
+
+    bool shouldResolve(EntityID a, EntityID b)
+    {
+        auto& manager = EC_DOD_EntityManager::getInstance();
+        const bool aHasRB = manager.hasComponent<EC_DOD_RigidBody>(a);
+        const bool bHasRB = manager.hasComponent<EC_DOD_RigidBody>(b);
+
+        // Neither side is a dynamic body (e.g. two purely static/visual
+        // entities sharing a collider) - nothing for physics to do.
+        if (!aHasRB && !bHasRB) return false;
+
+        // A missing RigidBody, or an explicit isStatic, behaves like "asleep"
+        // for this purpose - it never has real motion and never needs waking.
+        const bool aAsleep = aHasRB && manager.getComponent<EC_DOD_RigidBody>(a).isSleeping;
+        const bool bAsleep = bHasRB && manager.getComponent<EC_DOD_RigidBody>(b).isSleeping;
+        const bool aAtRest = !aHasRB || aAsleep || manager.getComponent<EC_DOD_RigidBody>(a).isStatic;
+        const bool bAtRest = !bHasRB || bAsleep || manager.getComponent<EC_DOD_RigidBody>(b).isStatic;
+
+        if (aAtRest && bAtRest) {
+            return false; // both sides at rest relative to each other - resolving
+                           // this every frame is exactly what re-injects drift.
+        }
+
+        // The other side has real motion - wake whichever side is asleep so
+        // it actually reacts this frame.
+        if (aAsleep) {
+            auto& rb = manager.getComponent<EC_DOD_RigidBody>(a);
+            rb.isSleeping = false;
+            rb.sleepTimer = 0.0f;
+        }
+        if (bAsleep) {
+            auto& rb = manager.getComponent<EC_DOD_RigidBody>(b);
+            rb.isSleeping = false;
+            rb.sleepTimer = 0.0f;
+        }
+
+        return true;
+    }
+
+    void correctPosition(EntityID a, EntityID b, const CollisionManifold& manifold)
+    {
+        if (glm::dot(manifold.contactNormal, manifold.contactNormal) < kEpsilon) return;
+        if (manifold.penetrationDepth <= kPenetrationSlop) return;
+        if (manifold.contactPoints.empty()) return;
+
+        auto& manager = EC_DOD_EntityManager::getInstance();
+        ResolvedBody bodyA = resolveBody(manager, a);
+        ResolvedBody bodyB = resolveBody(manager, b);
+
+        const float invMassSum = bodyA.invMass + bodyB.invMass;
+        if (invMassSum <= kEpsilon) return;
+
+        if (!manager.hasComponent<EC_DOD_Spatial>(a) || !manager.hasComponent<EC_DOD_Spatial>(b)) return;
+        auto& spatialA = manager.getComponent<EC_DOD_Spatial>(a);
+        auto& spatialB = manager.getComponent<EC_DOD_Spatial>(b);
+
+        // Translation only - deliberately does NOT touch orientation.
+        // correctPosition's job is cleaning up small residual overlap left
+        // over after velocity resolution, not driving rotation - rotation
+        // belongs entirely to the velocity solver (accumulateImpulses),
+        // where it's expressed as real angVelocity: integrated normally,
+        // damped normally, and visible to the sleep system. An earlier
+        // version of this function also nudged orientation directly here
+        // (a per-point pseudo-torque, mirroring the velocity solver's
+        // r-cross-impulse formula) - for a body sitting in a SUSTAINED
+        // asymmetric contact (e.g. leaning against a neighbour rather than
+        // resting flat), gravity regenerates the same small overlap every
+        // tick, so that correction reapplied every tick too, in the same
+        // direction, accumulating into a large rotation over many seconds -
+        // entirely outside spatial.angVelocity, so the sleep system (which
+        // only ever looks at velocity) had no way to see or stop it. Straight
+        // translation split evenly across every point avoids that failure
+        // mode entirely: it can only ever separate the bodies, never spin
+        // one - if something in the scene needs a body to rotate, that
+        // has to come from a real, measurable angular velocity, not a
+        // position-space nudge with no velocity behind it.
+        const float excessDepth = manifold.penetrationDepth - kPenetrationSlop;
+        const float correctionMag = excessDepth / invMassSum * kPositionCorrectionPercent;
+        const glm::vec3 correction = correctionMag * manifold.contactNormal;
+
+        if (bodyA.invMass > 0.0f) spatialA.position -= correction * bodyA.invMass;
+        if (bodyB.invMass > 0.0f) spatialB.position += correction * bodyB.invMass;
+    }
+
+    void wakeIfSleeping(EntityID entity)
+    {
+        auto& manager = EC_DOD_EntityManager::getInstance();
+        if (!manager.hasComponent<EC_DOD_RigidBody>(entity)) return;
+
+        auto& rb = manager.getComponent<EC_DOD_RigidBody>(entity);
+        if (rb.isSleeping) {
+            rb.isSleeping = false;
+            rb.sleepTimer = 0.0f;
+        }
+    }
+
+    void previewVelocity(EntityID entity, glm::vec3& outVel, glm::vec3& outAngVel)
+    {
+        auto& manager = EC_DOD_EntityManager::getInstance();
+        outVel = glm::vec3(0.0f);
+        outAngVel = glm::vec3(0.0f);
+        if (manager.hasComponent<EC_DOD_Spatial>(entity)) {
+            const auto& spatial = manager.getComponent<EC_DOD_Spatial>(entity);
+            outVel = spatial.velocity;
+            outAngVel = spatial.angVelocity;
+        }
+
+        if (!manager.hasComponent<EC_DOD_RigidBody>(entity)) return;
+        const auto& rb = manager.getComponent<EC_DOD_RigidBody>(entity);
+        if (rb.isStatic || rb.mass <= kEpsilon) return;
+        if (!manager.hasComponent<EC_DOD_ImpulseAccumulator>(entity)) return;
+
+        const auto& accum = manager.getComponent<EC_DOD_ImpulseAccumulator>(entity);
+        const float invMass = 1.0f / rb.mass;
+        const glm::mat3 invInertiaWorld = computeInvInertiaWorld(entity, rb.mass);
+        outVel += accum.deltaLinearMomentum * invMass;
+        outAngVel += invInertiaWorld * accum.deltaAngularMomentum;
+    }
+}

--- a/src/Engine/Subsystems/CollisionSystems/EC_PhysicsResolution.h
+++ b/src/Engine/Subsystems/CollisionSystems/EC_PhysicsResolution.h
@@ -1,0 +1,144 @@
+#pragma once
+#include "Entity/EC_DOD_Types.h"
+#include "EC_CollisionShapes.h"
+#include "EC_PairManager.h"
+#include <glm/glm.hpp>
+
+namespace EC_PhysicsResolution
+{
+    // Stage 1 of 2 (collision resolution). Computes the normal + friction
+    // impulse at every contact point in the manifold - based on the bodies'
+    // velocities as of the start of this tick, not updated between points -
+    // and adds the resulting linear/angular momentum contributions to each
+    // body's EC_DOD_ImpulseAccumulator. Does NOT touch EC_DOD_Spatial
+    // velocity/angVelocity at all; that happens in stage 2 (see
+    // EC_PhysicsSystem), which consumes every body's accumulator alongside
+    // gravity and damping in one place. Entities without an EC_DOD_RigidBody
+    // are treated as infinite-mass/static, so any existing scene geometry
+    // acts as a solid obstacle with no changes required.
+    //
+    // Purely a velocity-space impulse: cancels closing velocity (with
+    // restitution) at every contact point, nothing else. Penetration depth
+    // is NOT folded in here - that's correctPosition's job, run once per
+    // pair separately after velocity resolution. Combining a velocity-space
+    // depth bias with a direct position correction double-corrects (the
+    // position fix removes the overlap, but the bias-driven separating
+    // velocity it also added is still there and keeps pushing the body
+    // apart on top of that), which is why the two are kept fully separate.
+    //
+    // velA/angVelA/velB/angVelB are the velocities this call resolves
+    // against - NOT read from EC_DOD_Spatial internally, so the caller
+    // controls exactly what "start of tick" means. For a single isolated
+    // pair that's just each body's real EC_DOD_Spatial velocity. For a body
+    // touching multiple pairs at once (e.g. a cube in a stack, resting on
+    // one neighbour and freshly struck by another), a single pass across
+    // all pairs computed against the real, un-updated Spatial velocity
+    // can't converge - the floor's support impulse doesn't "see" a fresh
+    // downward hit from above still landing this same tick, so it
+    // undercorrects. EC_PhysicsSystem resolves this sequentially across all
+    // pairs, each pair reading every earlier pair's result so far this tick
+    // (via previewVelocity below), rather than calling this with raw
+    // Spatial.
+    //
+    // contactCache is this pair's persistent per-contact-point accumulated
+    // impulse (warm starting), already prepared for this tick by exactly
+    // one prior call to warmStartPair (see below) - indexed 1:1 with
+    // manifold.contactPoints. This may be called several times per tick
+    // (one per solver pass); each call refines the running totals already
+    // in contactCache further, it does not re-seed them - re-seeding on
+    // every pass would double-apply the warm start.
+    void accumulateImpulses(EntityID a, EntityID b, const CollisionManifold& manifold,
+        const glm::vec3& velA, const glm::vec3& angVelA,
+        const glm::vec3& velB, const glm::vec3& angVelB,
+        std::vector<EC_ContactImpulseCache>& contactCache);
+
+    // Call exactly once per pair per tick, before any accumulateImpulses
+    // calls for it. Matches this tick's contactPoints to last tick's cache
+    // by closest position (within a small radius) and carries over each
+    // matched point's normal impulse as this tick's starting guess -
+    // "warm starting" - immediately applying it to both bodies'
+    // EC_DOD_ImpulseAccumulator so every subsequent previewVelocity call
+    // this tick (across every solver pass) reflects it. Unmatched points
+    // (a genuinely new contact) start at zero, same as with no warm
+    // starting at all. Friction is deliberately NOT carried over - its
+    // tangent direction is derived from the current slip direction each
+    // call, which can rotate tick-to-tick, so a carried-over magnitude
+    // wouldn't cleanly apply to a different direction. This is what
+    // actually lets a sustained contact (a resting or tumbling box)
+    // converge tick-to-tick instead of re-deriving - and re-injecting
+    // solver noise from - a fresh answer every single frame. Standard
+    // technique in every production physics engine.
+    void warmStartPair(EntityID a, EntityID b, const CollisionManifold& manifold,
+        std::vector<EC_ContactImpulseCache>& contactCache);
+
+    // Returns entity's real EC_DOD_Spatial velocity/angular velocity plus
+    // whatever its EC_DOD_ImpulseAccumulator has accumulated so far this
+    // tick, converted through invMass/invInertia - i.e. "the velocity this
+    // body would have if step 2 applied the accumulator right now, minus
+    // gravity/damping (which are step 2's job, not relevant mid-solve)".
+    // Called before resolving every pair, so each pair sees every earlier
+    // pair's contribution so far this tick (sequential/Gauss-Seidel, not a
+    // frozen per-sweep snapshot); entities without a RigidBody (static
+    // geometry) just return their Spatial velocity unchanged (always zero
+    // for genuinely static geometry).
+    void previewVelocity(EntityID entity, glm::vec3& outVel, glm::vec3& outAngVel);
+
+    // Call once per pair, before accumulating its impulses, to apply sleep
+    // bookkeeping: wakes a sleeping body if the other side of the pair has
+    // real motion, and returns false (meaning skip accumulateImpulses/
+    // correctPosition this frame) when both sides are already at rest
+    // relative to each other - resolving an already-settled pair every frame
+    // is exactly what re-injects the tiny numerical drift sleeping exists to
+    // prevent.
+    bool shouldResolve(EntityID a, EntityID b);
+
+    // Wakes the entity if it has a sleeping RigidBody, no-op otherwise. Call
+    // when a pair stops colliding (CollisionEndEvent) - a sleeping body may
+    // have been resting on whatever it just separated from (e.g. knocked out
+    // from under it), so losing that contact needs to re-evaluate it rather
+    // than leaving it frozen mid-air with nothing left holding it up.
+    void wakeIfSleeping(EntityID entity);
+
+    // Direct positional correction: separates a and b along the manifold
+    // normal by a fraction of the excess penetration (beyond slop), no
+    // velocity/momentum involved. Companion to accumulateImpulses'
+    // velocity-space resolution, not a replacement for it - velocity
+    // resolution is rate-limited by construction (it only closes a
+    // fraction of the gap per second, however stiff), so a body under
+    // sustained load (e.g. still supporting the rest of a stack) settles
+    // into an equilibrium at whatever depth balances that rate against the
+    // load, and a fast transient impact can outrun it entirely before it
+    // catches up. Direct position correction has no such rate limit -
+    // called once per still-colliding pair, after velocity has already
+    // been resolved, it closes most of the gap immediately regardless of
+    // load or impact speed. Standard technique (every mainstream engine
+    // pairs the two for this exact reason).
+    //
+    // Translation only - deliberately never touches orientation. A version
+    // of this that also nudged orientation directly (a per-point pseudo-
+    // torque split across manifold.contactPoints, intended to fix tilted
+    // contacts a pure translation can't) was tried and reverted: for a
+    // body in a SUSTAINED asymmetric contact (leaning against a neighbour
+    // rather than resting flat), gravity regenerates the same small
+    // overlap every tick, so that correction reapplied every tick too, in
+    // the same direction, silently accumulating into a large rotation over
+    // many seconds - entirely outside spatial.angVelocity, so the sleep
+    // system (which only ever looks at velocity) had no way to see or stop
+    // it. Rotation belongs entirely to the velocity solver
+    // (accumulateImpulses) - if a body needs to rotate, that has to come
+    // from a real, measurable angular velocity, not a position-space nudge
+    // with no velocity behind it.
+    void correctPosition(EntityID a, EntityID b, const CollisionManifold& manifold);
+
+    // Diagonal inverse inertia tensor for entity's collider shape, rotated
+    // into world space (sphere: 2/5*m*r^2; box: standard 1/12*m*(h^2+d^2) per
+    // axis, using the OBB's current orientation - AABB colliders don't
+    // rotate so use the identity orientation). Shared between stage 1
+    // (computing angular impulse denominators) and stage 2 (turning
+    // accumulated angular momentum into angular velocity) so both use
+    // exactly the same inertia. Capsule/Cylinder/etc have no
+    // collision-response dispatch entries at all (pre-existing gap), so they
+    // fall back to infinite inertia (zero matrix - no rotation imparted)
+    // rather than guessing a formula.
+    glm::mat3 computeInvInertiaWorld(EntityID entity, float mass);
+}

--- a/src/Engine/Subsystems/CollisionSystems/EC_VClip.cpp
+++ b/src/Engine/Subsystems/CollisionSystems/EC_VClip.cpp
@@ -1,0 +1,343 @@
+#include "EC_VClip.h"
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+    constexpr float kEpsilon = 1e-5f;
+    // Tolerance for "is this local coordinate at the box's boundary" (feature
+    // classification) and "is this point within the face's lateral extent"
+    // (face clipping) - deliberately much looser than kEpsilon above. A
+    // resting box's position/orientation accumulates ordinary floating-point
+    // drift well above 1e-5 tick to tick (from position correction, impulse
+    // integration, etc), so a corner sitting almost exactly at the boundary
+    // would otherwise flip between "on the face" and "off it" depending on
+    // which side of 1e-5 that noise happened to land on - flickering the
+    // manifold's point count (2/3/4) every few ticks even for a box at
+    // genuine rest, which feeds inconsistent torque/friction budgets into
+    // the solver and reads as slow unexplained creep. 1e-3 is still far
+    // tighter than anything that should register as a real geometric
+    // difference at this engine's unit scale.
+    constexpr float kFeatureEpsilon = 1e-3f;
+
+    // 8 local-space vertices, indexed by a sign triple packed into 3 bits
+    // (bit0 = X sign, bit1 = Y sign, bit2 = Z sign; 1 = +halfExtent, 0 = -halfExtent).
+    glm::vec3 vertexLocal(int idx, const glm::vec3& he)
+    {
+        return glm::vec3(
+            (idx & 1) ? he.x : -he.x,
+            (idx & 2) ? he.y : -he.y,
+            (idx & 4) ? he.z : -he.z);
+    }
+
+    // 12 edges as vertex-index pairs - each pair differs in exactly one bit
+    // (the axis the edge runs along). Grouped by that axis: vary X, vary Y, vary Z.
+    constexpr int kEdgeVertices[12][2] = {
+        {0,1},{2,3},{4,5},{6,7},   // vary X
+        {0,2},{1,3},{4,6},{5,7},   // vary Y
+        {0,4},{1,5},{2,6},{3,7},   // vary Z
+    };
+
+    // Face index = axis*2 + (sign>0 ? 1 : 0).
+    int faceAxisOf(int f) { return f / 2; }
+    float faceSignOf(int f) { return (f % 2) ? 1.0f : -1.0f; }
+
+    int edgeVaryAxis(int e)
+    {
+        int v0 = kEdgeVertices[e][0], v1 = kEdgeVertices[e][1];
+        int diff = v0 ^ v1;
+        return (diff == 1) ? 0 : (diff == 2) ? 1 : 2;
+    }
+
+    // Local-space closest point on/in a box to local point q, plus which
+    // feature (vertex/edge/face) that point belongs to. For a box, whose
+    // faces are axis-aligned in its own local frame, this clamp-and-count
+    // test IS the Voronoi-region membership test: an axis needing clamping
+    // means q is beyond that face's plane, and the SET of axes that needed
+    // clamping exactly identifies the feature (1 -> face, 2 -> edge, 3 ->
+    // vertex) - no separate per-feature half-plane tests are needed. If q is
+    // strictly inside the box (the two interpenetrating-body case), fall
+    // back to the axis with the least penetration margin, matching SAT's own
+    // face choice for a body in isolation.
+    EC_VClip::Feature classifyLocalPoint(const glm::vec3& q, const glm::vec3& he, glm::vec3& outClosestLocal)
+    {
+        bool clamped[3] = { false, false, false };
+        float sign[3] = { 0.0f, 0.0f, 0.0f };
+        int numClamped = 0;
+        glm::vec3 closest = q;
+
+        for (int axis = 0; axis < 3; axis++)
+        {
+            if (q[axis] > he[axis] - kFeatureEpsilon)
+            {
+                clamped[axis] = true; sign[axis] = 1.0f; closest[axis] = he[axis]; numClamped++;
+            }
+            else if (q[axis] < -he[axis] + kFeatureEpsilon)
+            {
+                clamped[axis] = true; sign[axis] = -1.0f; closest[axis] = -he[axis]; numClamped++;
+            }
+        }
+
+        if (numClamped == 0)
+        {
+            int bestAxis = 0;
+            float bestMargin = he.x - std::abs(q.x);
+            for (int axis = 1; axis < 3; axis++)
+            {
+                float margin = he[axis] - std::abs(q[axis]);
+                if (margin < bestMargin) { bestMargin = margin; bestAxis = axis; }
+            }
+            clamped[bestAxis] = true;
+            sign[bestAxis] = (q[bestAxis] >= 0.0f) ? 1.0f : -1.0f;
+            closest[bestAxis] = sign[bestAxis] * he[bestAxis];
+            numClamped = 1;
+        }
+
+        outClosestLocal = closest;
+
+        EC_VClip::Feature feature;
+        if (numClamped == 1)
+        {
+            int axis = clamped[0] ? 0 : (clamped[1] ? 1 : 2);
+            feature.type = EC_VClip::FeatureType::Face;
+            feature.index = axis * 2 + (sign[axis] > 0.0f ? 1 : 0);
+        }
+        else if (numClamped == 2)
+        {
+            int varyAxis = clamped[0] ? (clamped[1] ? 2 : 1) : 0;
+            feature.type = EC_VClip::FeatureType::Edge;
+            feature.index = 0;
+            for (int e = 0; e < 12; e++)
+            {
+                if (edgeVaryAxis(e) != varyAxis) continue;
+                int v0 = kEdgeVertices[e][0];
+                bool match = true;
+                for (int axis = 0; axis < 3; axis++)
+                {
+                    if (axis == varyAxis || !clamped[axis]) continue;
+                    float vSign = (v0 & (1 << axis)) ? 1.0f : -1.0f;
+                    if (vSign != sign[axis]) { match = false; break; }
+                }
+                if (match) { feature.index = e; break; }
+            }
+        }
+        else
+        {
+            int idx = 0;
+            for (int axis = 0; axis < 3; axis++) if (sign[axis] > 0.0f) idx |= (1 << axis);
+            feature.type = EC_VClip::FeatureType::Vertex;
+            feature.index = idx;
+        }
+        return feature;
+    }
+
+    std::vector<glm::vec3> featureWorldPoints(const EC_VClip::Feature& f, const glm::vec3& center,
+        const glm::mat3& orient, const glm::vec3& he)
+    {
+        if (f.type == EC_VClip::FeatureType::Vertex)
+            return { center + orient * vertexLocal(f.index, he) };
+
+        if (f.type == EC_VClip::FeatureType::Edge)
+        {
+            glm::vec3 v0 = vertexLocal(kEdgeVertices[f.index][0], he);
+            glm::vec3 v1 = vertexLocal(kEdgeVertices[f.index][1], he);
+            return { center + orient * v0, center + orient * v1 };
+        }
+
+        return {};
+    }
+
+    // Keeps only points that project, in the face-box's local frame, within
+    // the face's rectangular lateral extent (the two axes other than the
+    // face's own normal axis) - i.e. points genuinely over the face, not off
+    // one of its edges.
+    std::vector<glm::vec3> clipPointsAgainstFace(const std::vector<glm::vec3>& worldPoints,
+        const glm::vec3& faceBoxCenter, const glm::mat3& faceBoxOrient, const glm::vec3& faceBoxHalfExtents,
+        int faceIndex)
+    {
+        int faceAx = faceAxisOf(faceIndex);
+        int u = (faceAx + 1) % 3, v = (faceAx + 2) % 3;
+        glm::mat3 invOrient = glm::transpose(faceBoxOrient);
+
+        std::vector<glm::vec3> result;
+        for (const glm::vec3& p : worldPoints)
+        {
+            glm::vec3 local = invOrient * (p - faceBoxCenter);
+            if (std::abs(local[u]) <= faceBoxHalfExtents[u] + kFeatureEpsilon &&
+                std::abs(local[v]) <= faceBoxHalfExtents[v] + kFeatureEpsilon)
+            {
+                result.push_back(p);
+            }
+        }
+        return result;
+    }
+
+    // The 4 world-space corners of one face of a box - identical to the
+    // helper formerly local to EC_CollisionChecks.cpp's OBBVsOBB; moved here
+    // since face-face manifold generation now lives in this module.
+    std::vector<glm::vec3> boxFaceCorners(const glm::vec3& center, const glm::vec3& he,
+        const glm::mat3& orient, int axis, float sign)
+    {
+        int u = (axis + 1) % 3, v = (axis + 2) % 3;
+        glm::vec3 faceLocalCenter(0.0f);
+        faceLocalCenter[axis] = sign * he[axis];
+
+        std::vector<glm::vec3> corners;
+        corners.reserve(4);
+        for (float su : { -1.0f, 1.0f })
+        {
+            for (float sv : { -1.0f, 1.0f })
+            {
+                glm::vec3 local = faceLocalCenter;
+                local[u] = su * he[u];
+                local[v] = sv * he[v];
+                corners.push_back(center + orient * local);
+            }
+        }
+        // Reorder to a consistent winding (su,sv) = (-,-),(+,-),(+,+),(-,+)
+        std::swap(corners[2], corners[3]);
+        return corners;
+    }
+
+    std::vector<glm::vec3> clipPolygonAgainstPlane(const std::vector<glm::vec3>& poly,
+        const glm::vec3& planePoint, const glm::vec3& planeNormal)
+    {
+        if (poly.size() < 2) return poly;
+
+        std::vector<glm::vec3> result;
+        result.reserve(poly.size() + 1);
+
+        for (size_t i = 0; i < poly.size(); i++)
+        {
+            const glm::vec3& current = poly[i];
+            const glm::vec3& next = poly[(i + 1) % poly.size()];
+
+            float distCurrent = glm::dot(current - planePoint, planeNormal);
+            float distNext = glm::dot(next - planePoint, planeNormal);
+
+            bool currentInside = distCurrent <= kEpsilon;
+            bool nextInside = distNext <= kEpsilon;
+
+            if (currentInside) result.push_back(current);
+
+            if (currentInside != nextInside)
+            {
+                float denom = distCurrent - distNext;
+                if (std::abs(denom) > kEpsilon)
+                {
+                    float t = distCurrent / denom;
+                    result.push_back(current + t * (next - current));
+                }
+            }
+        }
+        return result;
+    }
+}
+
+namespace EC_VClip
+{
+    void generateContactPoints(
+        const OBB& obbA, const glm::vec3& posA,
+        const OBB& obbB, const glm::vec3& posB,
+        const glm::vec3& normal, float /*penetrationDepth*/,
+        CollisionManifold& manifold)
+    {
+        const glm::vec3 centerA = posA + obbA.center;
+        const glm::vec3 centerB = posB + obbB.center;
+
+        // Seed the walk at the closest point ON box A to box B's CENTRE
+        // (transform B's centre into A's local frame, clamp to A's extents) -
+        // not merely offset along the SAT normal from A's own centre. That
+        // distinction matters: for a small box resting on a huge floor slab,
+        // seeding purely along the normal from the floor's centre leaves the
+        // seed's lateral (X/Z) position at the FLOOR's centre, nowhere near
+        // where the box actually is - which then misclassifies against the
+        // box (the seed can land on one of the box's SIDE faces rather than
+        // its bottom face, since the box's own centre is offset from the
+        // floor's centre by more than the box's half-extent). Clamping B's
+        // centre into A's frame instead keeps the seed's lateral position
+        // tied to B's actual location, converging to the right feature pair
+        // reliably regardless of how large the size mismatch is.
+        glm::vec3 candidateWorld;
+        {
+            glm::vec3 localBCenterInA = glm::transpose(obbA.orientation) * (centerB - centerA);
+            glm::vec3 seedLocal;
+            classifyLocalPoint(localBCenterInA, obbA.halfExtents, seedLocal);
+            candidateWorld = centerA + obbA.orientation * seedLocal;
+        }
+
+        Feature featureA{}, featureB{};
+        glm::vec3 worldClosestA(0.0f), worldClosestB(0.0f);
+
+        constexpr int kMaxIterations = 12;
+        for (int iter = 0; iter < kMaxIterations; iter++)
+        {
+            glm::vec3 closestLocalA, closestLocalB;
+
+            glm::vec3 localA = glm::transpose(obbA.orientation) * (candidateWorld - centerA);
+            featureA = classifyLocalPoint(localA, obbA.halfExtents, closestLocalA);
+            worldClosestA = centerA + obbA.orientation * closestLocalA;
+
+            glm::vec3 localB = glm::transpose(obbB.orientation) * (candidateWorld - centerB);
+            featureB = classifyLocalPoint(localB, obbB.halfExtents, closestLocalB);
+            worldClosestB = centerB + obbB.orientation * closestLocalB;
+
+            glm::vec3 nextCandidate = 0.5f * (worldClosestA + worldClosestB);
+            glm::vec3 delta = nextCandidate - candidateWorld;
+            candidateWorld = nextCandidate;
+            if (glm::dot(delta, delta) < 1e-8f) break;
+        }
+
+        manifold.contactPoints.clear();
+
+        const bool aIsFace = (featureA.type == FeatureType::Face);
+        const bool bIsFace = (featureB.type == FeatureType::Face);
+
+        if (aIsFace && bIsFace)
+        {
+            // Genuine face-face rest: full Sutherland-Hodgman clip, exactly
+            // as before - reference face A, incident face B.
+            int refAxis = faceAxisOf(featureA.index);
+            float refSign = faceSignOf(featureA.index);
+            int u = (refAxis + 1) % 3, v = (refAxis + 2) % 3;
+            glm::vec3 uAxisWorld = obbA.orientation[u];
+            glm::vec3 vAxisWorld = obbA.orientation[v];
+
+            glm::vec3 refFaceLocal(0.0f);
+            refFaceLocal[refAxis] = refSign * obbA.halfExtents[refAxis];
+            glm::vec3 refFaceCenterWorld = centerA + obbA.orientation * refFaceLocal;
+
+            std::vector<glm::vec3> poly = boxFaceCorners(centerB, obbB.halfExtents, obbB.orientation,
+                faceAxisOf(featureB.index), faceSignOf(featureB.index));
+
+            poly = clipPolygonAgainstPlane(poly, refFaceCenterWorld + uAxisWorld * obbA.halfExtents[u], uAxisWorld);
+            poly = clipPolygonAgainstPlane(poly, refFaceCenterWorld - uAxisWorld * obbA.halfExtents[u], -uAxisWorld);
+            poly = clipPolygonAgainstPlane(poly, refFaceCenterWorld + vAxisWorld * obbA.halfExtents[v], vAxisWorld);
+            poly = clipPolygonAgainstPlane(poly, refFaceCenterWorld - vAxisWorld * obbA.halfExtents[v], -vAxisWorld);
+
+            glm::vec3 refNormalWorld = obbA.orientation[refAxis] * refSign;
+            for (const glm::vec3& p : poly)
+            {
+                float depth = glm::dot(refFaceCenterWorld - p, refNormalWorld);
+                if (depth >= -0.005f) manifold.contactPoints.push_back(p);
+            }
+        }
+        else if (aIsFace)
+        {
+            auto pts = featureWorldPoints(featureB, centerB, obbB.orientation, obbB.halfExtents);
+            auto clipped = clipPointsAgainstFace(pts, centerA, obbA.orientation, obbA.halfExtents, featureA.index);
+            manifold.contactPoints = clipped;
+        }
+        else if (bIsFace)
+        {
+            auto pts = featureWorldPoints(featureA, centerA, obbA.orientation, obbA.halfExtents);
+            auto clipped = clipPointsAgainstFace(pts, centerB, obbB.orientation, obbB.halfExtents, featureB.index);
+            manifold.contactPoints = clipped;
+        }
+
+        if (manifold.contactPoints.empty())
+        {
+            manifold.contactPoints = { 0.5f * (worldClosestA + worldClosestB) };
+        }
+    }
+}

--- a/src/Engine/Subsystems/CollisionSystems/EC_VClip.h
+++ b/src/Engine/Subsystems/CollisionSystems/EC_VClip.h
@@ -1,0 +1,41 @@
+#pragma once
+#include "EC_CollisionShapes.h"
+#include <glm/glm.hpp>
+
+// Box-specialised V-Clip: given two OBBs already known to overlap (from
+// OBBVsOBB's 15-axis SAT test) plus that test's normal/depth, walks to the
+// TRUE closest feature pair (vertex/edge/face on each box) via local-frame
+// Voronoi-region classification, then generates the resulting contact
+// point(s). This replaces choosing the manifold shape from SAT's raw numeric
+// overlap comparison, which misclassifies "edge-edge" for grossly mismatched
+// body sizes (e.g. a cube vs a room-sized floor slab) - the numeric overlap
+// values can be close even when the TRUE closest feature is obviously the
+// floor's face, and a contact point computed from the floor's actual
+// geometric edges (sitting at the slab's far perimeter) has nothing to do
+// with where the cube is really touching down.
+namespace EC_VClip
+{
+    enum class FeatureType { Vertex, Edge, Face };
+
+    // index meaning depends on type: vertex 0-7, edge 0-11, face 0-5 - see the
+    // topology tables in EC_VClip.cpp for exactly what each index represents.
+    struct Feature
+    {
+        FeatureType type = FeatureType::Face;
+        int index = 0;
+    };
+
+    // Walks from the SAT-provided normal (used only as an initial seed point -
+    // the walk corrects it if wrong) to the true closest feature pair, then
+    // fills manifold.contactPoints (1 point for any vertex/edge-involving pair,
+    // up to 4 for a genuine face-face rest, via the same Sutherland-Hodgman
+    // clip used before). Does not touch manifold.contactNormal/
+    // penetrationDepth - those stay authoritative from the SAT stage, which is
+    // already correct and robust; this function's only job is picking the
+    // right feature pair and contact location.
+    void generateContactPoints(
+        const OBB& obbA, const glm::vec3& posA,
+        const OBB& obbB, const glm::vec3& posB,
+        const glm::vec3& normal, float penetrationDepth,
+        CollisionManifold& manifold);
+}

--- a/src/Engine/Subsystems/EC_LuaScriptingSystem.h
+++ b/src/Engine/Subsystems/EC_LuaScriptingSystem.h
@@ -357,6 +357,8 @@ private:
             .addFunction("getEntityIDByUID", &ScriptAPI::GameAPI::getEntityIDByUID)
             .addFunction("getKeyState", &ScriptAPI::GameAPI::getKeyState)
             .addFunction("shutdown", &ScriptAPI::GameAPI::shutdown)
+            .addFunction("pauseGame", &ScriptAPI::GameAPI::pauseGame)
+            .addFunction("resumeGame", &ScriptAPI::GameAPI::resumeGame)
             .addFunction("setParent", &ScriptAPI::GameAPI::setParent)
             .addFunction("clearParent", &ScriptAPI::GameAPI::clearParent)
             .addFunction("toggleDebug", &ScriptAPI::GameAPI::toggleDebug)

--- a/src/Engine/Subsystems/EC_PhysicsSystem.cpp
+++ b/src/Engine/Subsystems/EC_PhysicsSystem.cpp
@@ -1,0 +1,227 @@
+#include "Engine/Subsystems/EC_PhysicsSystem.h"
+#include "Entity/EC_DOD_EntityManager.h"
+#include "Components/EC_DOD_Components.h"
+#include "Engine/Subsystems/CollisionSystems/EC_PhysicsResolution.h"
+#include "Engine/Subsystems/CollisionSystems/EC_PairManager.h"
+#include "Engine/Subsystems/CollisionSystems/EC_CollisionShapes.h"
+#include <glm/gtc/matrix_transform.hpp>
+#include "Logging/ECX_Logging.h"
+
+EC_PhysicsSystem::EC_PhysicsSystem() {}
+EC_PhysicsSystem::~EC_PhysicsSystem() {}
+void EC_PhysicsSystem::init(ECXMessenger& messenger, EC_Game& game) {}
+
+namespace {
+    constexpr glm::vec3 kGravity(0.0f, -9.8f, 0.0f);
+    // Below these speeds, a body is considered "at rest" for sleep purposes.
+    constexpr float kSleepLinearThreshold = 0.05f;
+    constexpr float kSleepAngularThreshold = 0.01f;
+    // How long it must stay below threshold before actually going to sleep -
+    // avoids putting a body to sleep during a brief momentary lull. A body
+    // sitting just past an unstable equilibrium (e.g. supporting another
+    // body with its combined centre of mass no longer over its own base)
+    // has torque roughly proportional to sin(tilt), so its angular
+    // acceleration right at the start of a topple is genuinely tiny - it
+    // can sit under kSleepAngularThreshold for a while before visibly
+    // accelerating. A short window here reads that as "at rest" and freezes
+    // it mid-topple - and once asleep, gravity is skipped for it entirely
+    // (see the isSleeping check below), so it never resumes falling even
+    // though the configuration was never actually stable. 1 full second
+    // (60 frames at the engine's fixed 60Hz) gives a slow-building topple
+    // enough real time to build up past the threshold before being frozen;
+    // Box2D's own default (b2_timeToSleep) is 0.5s for comparison.
+    constexpr float kTimeToSleep = 60.0f / 60.0f;
+}
+
+void EC_PhysicsSystem::update(const float& deltaTimeS, EC_Game& game) {
+    auto& manager = EC_DOD_EntityManager::getInstance();
+
+    // --- Step 1: pairs only. Every pair the collision system found
+    // colliding this tick contributes a normal + friction impulse (per
+    // contact point in its cached manifold) into each body's
+    // EC_DOD_ImpulseAccumulator. Nothing else happens here - no gravity,
+    // no damping, no integration; those belong to step 2 below.
+    //
+    // Resolved sequentially (Gauss-Seidel) across every pair, several
+    // passes per tick, and warm-started from last tick's result (see
+    // EC_PhysicsResolution::accumulateImpulses/previewVelocity). Each
+    // pair's resolution reads every earlier pair's contribution so far
+    // this tick via previewVelocity (which reads the live, continuously-
+    // updated accumulator) - so a body touching multiple simultaneous
+    // contacts converges properly within the tick: e.g. a cube resting on
+    // the floor while a falling neighbour lands on it the same tick - the
+    // floor's support impulse now sees that fresh downward hit instead of
+    // resolving against stale velocity. Combined with warm starting
+    // (each contact's accumulated impulse persists tick-to-tick instead of
+    // restarting at zero every frame), this is the standard sequential-
+    // impulse architecture every production physics engine uses.
+    if (m_PairManager) {
+        // Warm start every still-colliding, resolvable pair exactly once
+        // per tick, before the multi-pass solve below - matches this
+        // tick's contact points to last tick's cache and seeds the real
+        // accumulator with each one's carried-over impulse, so every
+        // solver pass (and every other pair's previewVelocity) sees it as
+        // this tick's starting guess. Must run to completion here, not
+        // inside the pass loop, or it would double-apply on every pass.
+        for (EC_CollisionPair& pair : EC_PairManager::getAllPairs()) {
+            if (!pair.m_Colliding) continue;
+            if (!EC_PhysicsResolution::shouldResolve(pair.body_A, pair.body_B)) continue;
+
+            CollisionManifold manifold;
+            manifold.contactPoints = pair.m_CollisionPoints;
+            manifold.contactNormal = pair.m_ContactNormal;
+            manifold.penetrationDepth = pair.m_PenetrationDepth;
+            EC_PhysicsResolution::warmStartPair(pair.body_A, pair.body_B, manifold, pair.m_ContactCache);
+        }
+
+        constexpr int kSolverPasses = 4;
+        for (int pass = 0; pass < kSolverPasses; pass++) {
+            for (EC_CollisionPair& pair : EC_PairManager::getAllPairs()) {
+                if (!pair.m_Colliding) continue;
+                if (!EC_PhysicsResolution::shouldResolve(pair.body_A, pair.body_B)) continue;
+
+                CollisionManifold manifold;
+                manifold.contactPoints = pair.m_CollisionPoints;
+                manifold.contactNormal = pair.m_ContactNormal;
+                manifold.penetrationDepth = pair.m_PenetrationDepth;
+
+                glm::vec3 velA, angVelA, velB, angVelB;
+                EC_PhysicsResolution::previewVelocity(pair.body_A, velA, angVelA);
+                EC_PhysicsResolution::previewVelocity(pair.body_B, velB, angVelB);
+
+                EC_PhysicsResolution::accumulateImpulses(pair.body_A, pair.body_B, manifold,
+                    velA, angVelA, velB, angVelB, pair.m_ContactCache);
+            }
+        }
+
+        // --- Step 1b: direct positional correction, once per still-
+        // colliding pair, after velocity has converged above. The velocity
+        // bias inside accumulateImpulses is rate-limited by construction -
+        // a body under sustained load (e.g. still supporting the rest of a
+        // stack) settles at whatever depth balances that rate against the
+        // load, and a fast impact can outrun it before it catches up. This
+        // has no such limit: it closes most of the gap immediately,
+        // regardless of load or impact speed. Runs once (not per sweep) -
+        // it isn't part of the velocity solve's convergence, and repeating
+        // it would just overshoot. ---
+        for (const EC_CollisionPair& pair : EC_PairManager::getAllPairs()) {
+            if (!pair.m_Colliding) continue;
+            if (!EC_PhysicsResolution::shouldResolve(pair.body_A, pair.body_B)) continue;
+
+            CollisionManifold manifold;
+            manifold.contactPoints = pair.m_CollisionPoints;
+            manifold.contactNormal = pair.m_ContactNormal;
+            manifold.penetrationDepth = pair.m_PenetrationDepth;
+            EC_PhysicsResolution::correctPosition(pair.body_A, pair.body_B, manifold);
+        }
+    }
+
+    // --- Step 2: apply. Every awake, non-static rigid body consumes
+    // gravity + whatever step 1 (or a prior tick's leftover, though there
+    // shouldn't be any) cached in its accumulator, then integrates. ---
+    auto* rbArray = manager.getComponentArray<EC_DOD_RigidBody>();
+    if (!rbArray) return;
+
+    std::shared_lock lock(rbArray->getMutex());
+    auto& rigidBodies = rbArray->getData();
+
+    for (size_t i = 0; i < rigidBodies.size(); i++) {
+        auto& rb = rigidBodies[i];
+        EntityID entity = rbArray->getEntity(i);
+
+        if (rb.isStatic) continue;
+
+        if (!manager.hasComponent<EC_DOD_Spatial>(entity)) continue;
+        auto& spatial = manager.getComponent<EC_DOD_Spatial>(entity);
+
+        if (rb.isSleeping) {
+            continue; // frozen; woken by EC_PhysicsResolution when disturbed
+        }
+
+        const float invMass = (rb.mass > 1e-6f) ? (1.0f / rb.mass) : 0.0f;
+
+        // --- Gravity: a plain linear force, applied as a momentum
+        // contribution (mass * g * dt) same as any other impulse source. ---
+        glm::vec3 deltaLinearMomentum = kGravity * rb.mass * deltaTimeS;
+        glm::vec3 deltaAngularMomentum(0.0f);
+
+        // --- Cached impulses from this tick's collision resolution (step 1
+        // above, warm-started and converged across several solver passes). ---
+        if (manager.hasComponent<EC_DOD_ImpulseAccumulator>(entity)) {
+            auto& accum = manager.getComponent<EC_DOD_ImpulseAccumulator>(entity);
+            deltaLinearMomentum += accum.deltaLinearMomentum;
+            deltaAngularMomentum += accum.deltaAngularMomentum;
+            accum.deltaLinearMomentum = glm::vec3(0.0f);
+            accum.deltaAngularMomentum = glm::vec3(0.0f);
+        }
+
+        // --- Apply: linear first, then angular ---
+        spatial.velocity += deltaLinearMomentum * invMass;
+
+        const glm::mat3 invInertiaWorld = EC_PhysicsResolution::computeInvInertiaWorld(entity, rb.mass);
+        spatial.angVelocity += invInertiaWorld * deltaAngularMomentum;
+
+        // --- Damping: a per-second fractional velocity decay, independent
+        // of contact - models drag/internal energy loss. Distinct from
+        // friction (which only acts at a contact point) and from the
+        // impulse-based forces above. ---
+        spatial.velocity *= std::max(0.0f, 1.0f - rb.linearDamping * deltaTimeS);
+        spatial.angVelocity *= std::max(0.0f, 1.0f - rb.angularDamping * deltaTimeS);
+
+        // --- Sleep bookkeeping, now that this tick's velocity is final ---
+        const bool atRest =
+            glm::dot(spatial.velocity, spatial.velocity) < kSleepLinearThreshold * kSleepLinearThreshold &&
+            glm::dot(spatial.angVelocity, spatial.angVelocity) < kSleepAngularThreshold * kSleepAngularThreshold;
+        rb.sleepTimer = atRest ? (rb.sleepTimer + deltaTimeS) : 0.0f;
+        if (rb.sleepTimer >= kTimeToSleep) {
+            rb.isSleeping = true;
+            spatial.velocity = glm::vec3(0.0f);
+            spatial.angVelocity = glm::vec3(0.0f);
+            continue;
+        }
+
+        // --- Integrate position/orientation from the final velocity ---
+        spatial.position += spatial.velocity * deltaTimeS;
+        spatial.orientation += spatial.angVelocity * deltaTimeS;
+
+        // Rigid bodies can tumble around any axis, so they need a real
+        // 3-axis rotation - built the exact same way
+        // EC_TransformSystem::buildLocal composes the render matrix, so an
+        // OBB collider's orientation always matches what's rendered.
+        glm::mat4 rot(1.0f);
+        rot = glm::rotate(rot, spatial.orientation.x, glm::vec3(1.0f, 0.0f, 0.0f));
+        rot = glm::rotate(rot, spatial.orientation.y, glm::vec3(0.0f, 1.0f, 0.0f));
+        rot = glm::rotate(rot, spatial.orientation.z, glm::vec3(0.0f, 0.0f, 1.0f));
+
+        spatial.direction = glm::normalize(glm::vec3(rot * glm::vec4(0.0f, 0.0f, -1.0f, 0.0f)));
+        spatial.up = glm::normalize(glm::vec3(rot * glm::vec4(0.0f, 1.0f, 0.0f, 0.0f)));
+        spatial.right = glm::normalize(glm::vec3(rot * glm::vec4(1.0f, 0.0f, 0.0f, 0.0f)));
+    }
+
+    // Total system mechanical energy (kinetic + gravitational potential, not
+    // just kinetic - KE alone legitimately grows anytime something is simply
+    // falling, so it isn't a useful invariant on its own) across every awake
+    // dynamic body. Should only ever decrease (friction/damping/inelastic
+    // impacts dissipate it) or drop sharply when a body goes to sleep
+    // (excluded from the sum) - a sustained increase means the solver is
+    // injecting energy it shouldn't. Off by default; enable via
+    // EngineConfig.xml's <Physics><Debug><LogEnergy>true</LogEnergy>.
+    if (m_LogEnergy) {
+        static int s_EnergyTick = 0;
+        s_EnergyTick++;
+        float totalEnergy = 0.0f;
+        for (size_t i = 0; i < rigidBodies.size(); i++) {
+            auto& rb = rigidBodies[i];
+            if (rb.isStatic || rb.isSleeping) continue;
+            EntityID entity = rbArray->getEntity(i);
+            if (!manager.hasComponent<EC_DOD_Spatial>(entity)) continue;
+            auto& spatial = manager.getComponent<EC_DOD_Spatial>(entity);
+            totalEnergy += 0.5f * rb.mass * glm::dot(spatial.velocity, spatial.velocity);
+            totalEnergy += 0.5f * glm::dot(spatial.angVelocity, spatial.angVelocity);
+            totalEnergy += rb.mass * 9.8f * spatial.position.y;
+        }
+        LOGGING::ECX_Logger::GetInstance()->LogMessage(
+            "[ENERGY] tick=" + std::to_string(s_EnergyTick) + " total=" + std::to_string(totalEnergy),
+            LOGGING::LogLevel::INFORMATION);
+    }
+}

--- a/src/Engine/Subsystems/EC_PhysicsSystem.h
+++ b/src/Engine/Subsystems/EC_PhysicsSystem.h
@@ -1,0 +1,47 @@
+#pragma once
+#include "EC_System.h"
+
+class EC_PairManager;
+
+// Runs sequentially, on the same thread, right after EC_CollisionSystem -
+// collision detection only ever finds intersections and caches their
+// geometric manifold (contact points, normal, penetration depth) on the
+// pair; it computes no forces/impulses at all. This system owns all of
+// that: given the pair manager it's wired to at startup (setPairManager,
+// called once from EC_Engine::init), each tick it -
+//   1. iterates every currently-colliding pair, computing and caching the
+//      collision-related linear/angular impulse for both bodies involved
+//      (EC_PhysicsResolution::accumulateImpulses) into each body's
+//      EC_DOD_ImpulseAccumulator;
+//   2. then, for every awake non-static EC_DOD_RigidBody, applies gravity
+//      plus that cached accumulator (linear momentum first, then angular),
+//      then damping, then integrates position/orientation from the result
+//      and resets the accumulator for next tick's step 1 to refill.
+class EC_PhysicsSystem : public EC_System {
+public:
+    EC_PhysicsSystem();
+    virtual ~EC_PhysicsSystem();
+
+    virtual void init(ECXMessenger& messenger, EC_Game& game) override;
+    virtual void update(const float& deltaTimeS, EC_Game& game) override;
+
+    // Wired once at startup (EC_Engine::init) to the same EC_PairManager
+    // instance EC_CollisionSystem's broad/narrow phase populate.
+    void setPairManager(EC_PairManager* pairManager) { m_PairManager = pairManager; }
+
+    // Wired once at startup (EC_Engine::init, from EngineConfig.xml's
+    // <Physics><Debug><LogEnergy> flag) - when set, logs every tick's total
+    // system mechanical energy (kinetic + gravitational potential, summed
+    // across every awake dynamic body) via ECX_Logger. That's the correct
+    // invariant to watch for a real solver bug: it should only ever
+    // decrease (friction/damping/inelastic impacts dissipate it) or drop
+    // sharply when a body goes to sleep (excluded from the sum) - any
+    // sustained increase means the solver is injecting energy that
+    // shouldn't be there, as opposed to kinetic energy alone, which
+    // legitimately grows anytime something is simply falling.
+    void setLogEnergy(bool enabled) { m_LogEnergy = enabled; }
+
+private:
+    EC_PairManager* m_PairManager = nullptr;
+    bool m_LogEnergy = false;
+};

--- a/src/Engine/Subsystems/EC_SpatialSystem.cpp
+++ b/src/Engine/Subsystems/EC_SpatialSystem.cpp
@@ -13,6 +13,13 @@ EC_SpatialSystem::~EC_SpatialSystem() {
 void EC_SpatialSystem::init(ECXMessenger& messenger, EC_Game& game) {
 }
 
+// Handles simple, non-physics spatial movement only (camera, script-driven
+// entities via entity:setPosition/moveForward etc.) - anything with an
+// EC_DOD_RigidBody is skipped entirely and is fully owned by the two-stage
+// rigid-body pipeline instead: EC_PhysicsResolution (collision resolution,
+// caches impulses) followed by EC_PhysicsSystem (gravity + damping +
+// consuming those cached impulses + integration), which runs later this
+// same tick. Handling a RigidBody entity here too would double-integrate it.
 void EC_SpatialSystem::update(const float& deltaTimeS, EC_Game& game) {
     auto& manager = EC_DOD_EntityManager::getInstance();
     auto* spatialArray = manager.getComponentArray<EC_DOD_Spatial>();
@@ -26,6 +33,11 @@ void EC_SpatialSystem::update(const float& deltaTimeS, EC_Game& game) {
 
     for (size_t i = 0; i < spatials.size(); i++) {
         auto& spatial = spatials[i];
+
+        EntityID entity = spatialArray->getEntity(i);
+        if (manager.hasComponent<EC_DOD_RigidBody>(entity)) {
+            continue;
+        }
 
         spatial.position += spatial.velocity * deltaTimeS;
         spatial.orientation += spatial.angVelocity * deltaTimeS;

--- a/src/Engine/Subsystems/Scripting/EC_GameAPI.h
+++ b/src/Engine/Subsystems/Scripting/EC_GameAPI.h
@@ -36,6 +36,14 @@ namespace ScriptAPI
             if (game) game->shutDown();
         }
 
+        void pauseGame() {
+            if (game) game->pauseGame();
+        }
+
+        void resumeGame() {
+            if (game) game->resumeGame();
+        }
+
         int getKeyState(const std::string& key) {
             if (!game) return 0;
             SDL_Scancode scancode = SDL_GetScancodeFromName(key.c_str());

--- a/src/Entity/EC_DOD_EntityFactory.cpp
+++ b/src/Entity/EC_DOD_EntityFactory.cpp
@@ -25,6 +25,7 @@ std::unordered_map<std::string, std::string> EC_DOD_EntityFactory::s_MeshAliases
 std::unordered_map<std::string, EC_DOD_EntityFactory::ShaderPaths> EC_DOD_EntityFactory::s_ShaderAliases;
 std::unordered_map<std::string, std::string> EC_DOD_EntityFactory::s_ScriptAliases;
 std::unordered_map<std::string, TiXmlElement*> EC_DOD_EntityFactory::s_MaterialElements;
+std::unordered_map<std::string, EC_DOD_EntityFactory::PhysicsMaterial> EC_DOD_EntityFactory::s_PhysicsMaterials;
 TiXmlDocument EC_DOD_EntityFactory::s_ManifestDoc;
 
 EC_DOD_EntityFactory::EC_DOD_EntityFactory() {
@@ -68,6 +69,45 @@ void EC_DOD_EntityFactory::parseManifest(TiXmlElement* manifestElem)
         {
             s_ScriptAliases[alias] = child->GetText();
         }
+        else if (strcmp(child->Value(), "PhysicsMaterial") == 0)
+        {
+            PhysicsMaterial material;
+
+            auto massElem = child->FirstChildElement("Mass");
+            if (massElem && massElem->GetText())
+                material.mass = static_cast<float>(atof(massElem->GetText()));
+
+            auto restitutionElem = child->FirstChildElement("Restitution");
+            if (restitutionElem && restitutionElem->GetText())
+                material.restitution = static_cast<float>(atof(restitutionElem->GetText()));
+
+            auto frictionElem = child->FirstChildElement("Friction");
+            if (frictionElem && frictionElem->GetText())
+                material.friction = static_cast<float>(atof(frictionElem->GetText()));
+            // Defaults to the kinetic value above (no distinct static
+            // regime) unless the material explicitly overrides it - must
+            // come after the Friction parse above so it picks up whatever
+            // that just set.
+            material.staticFriction = material.friction;
+
+            auto staticFrictionElem = child->FirstChildElement("StaticFriction");
+            if (staticFrictionElem && staticFrictionElem->GetText())
+                material.staticFriction = static_cast<float>(atof(staticFrictionElem->GetText()));
+
+            auto rollingFrictionElem = child->FirstChildElement("RollingFriction");
+            if (rollingFrictionElem && rollingFrictionElem->GetText())
+                material.rollingFriction = static_cast<float>(atof(rollingFrictionElem->GetText()));
+
+            auto linearDampingElem = child->FirstChildElement("LinearDamping");
+            if (linearDampingElem && linearDampingElem->GetText())
+                material.linearDamping = static_cast<float>(atof(linearDampingElem->GetText()));
+
+            auto angularDampingElem = child->FirstChildElement("AngularDamping");
+            if (angularDampingElem && angularDampingElem->GetText())
+                material.angularDamping = static_cast<float>(atof(angularDampingElem->GetText()));
+
+            s_PhysicsMaterials[alias] = material;
+        }
         else if (strcmp(child->Value(), "PBRMaterial") == 0)
         {
             TiXmlElement* copy = static_cast<TiXmlElement*>(child->Clone());
@@ -86,6 +126,26 @@ void EC_DOD_EntityFactory::parseManifest(TiXmlElement* manifestElem)
         }
         child = child->NextSiblingElement();
     }
+}
+
+bool EC_DOD_EntityFactory::loadManifestFile(const std::string& filename)
+{
+    if (filename.empty()) return false;
+
+    TiXmlDocument doc(filename.c_str());
+    if (!doc.LoadFile())
+    {
+        LOGGING::ECX_Logger::GetInstance()->LogMessage(
+            "Failed to load manifest file: " + filename,
+            LOGGING::LogLevel::SEVERE);
+        return false;
+    }
+
+    TiXmlElement* root = doc.FirstChildElement();
+    if (!root || strcmp(root->Value(), "Manifest") != 0) return false;
+
+    parseManifest(root);
+    return true;
 }
 
 EntityID EC_DOD_EntityFactory::constructEntity(TiXmlElement& descriptor) {
@@ -146,6 +206,8 @@ EntityID EC_DOD_EntityFactory::constructEntity(TiXmlElement& descriptor) {
             parseCollider(elem, entity);
             hasCollider = true;
         }
+        else if (strcmp(elem->Value(), "RigidBody") == 0)
+            parseRigidBody(elem, entity);
         else if (strcmp(elem->Value(), "Hierarchy") == 0)
             parseHierarchy(elem, entity);
         else if (strcmp(elem->Value(), "Skybox") == 0)
@@ -765,6 +827,81 @@ void EC_DOD_EntityFactory::parseCollider(TiXmlElement* elem, EntityID entity) {
         collider.collisionMask = static_cast<uint32_t>(strtoul(maskElem->GetText(), nullptr, 0));
 
     manager.addComponent(entity, collider);
+}
+
+void EC_DOD_EntityFactory::parseRigidBody(TiXmlElement* elem, EntityID entity) {
+    auto& manager = EC_DOD_EntityManager::getInstance();
+    EC_DOD_RigidBody rigidBody;
+
+    // A named material seeds mass/restitution as defaults; explicit
+    // <Mass>/<Restitution> tags below still override it per-entity.
+    const char* materialAttr = elem->Attribute("material");
+    if (materialAttr)
+    {
+        auto it = s_PhysicsMaterials.find(materialAttr);
+        if (it != s_PhysicsMaterials.end())
+        {
+            rigidBody.mass = it->second.mass;
+            rigidBody.restitution = it->second.restitution;
+            rigidBody.friction = it->second.friction;
+            rigidBody.staticFriction = it->second.staticFriction;
+            rigidBody.rollingFriction = it->second.rollingFriction;
+            rigidBody.linearDamping = it->second.linearDamping;
+            rigidBody.angularDamping = it->second.angularDamping;
+        }
+        else
+        {
+            LOGGING::ECX_Logger::GetInstance()->LogMessage(
+                "RigidBody: unknown material '" + std::string(materialAttr) + "'",
+                LOGGING::LogLevel::WARNING);
+        }
+    }
+
+    auto massElem = elem->FirstChildElement("Mass");
+    if (massElem && massElem->GetText())
+        rigidBody.mass = static_cast<float>(atof(massElem->GetText()));
+
+    auto restitutionElem = elem->FirstChildElement("Restitution");
+    if (restitutionElem && restitutionElem->GetText())
+        rigidBody.restitution = static_cast<float>(atof(restitutionElem->GetText()));
+
+    auto frictionElem = elem->FirstChildElement("Friction");
+    if (frictionElem && frictionElem->GetText())
+        rigidBody.friction = static_cast<float>(atof(frictionElem->GetText()));
+
+    auto staticFrictionElem = elem->FirstChildElement("StaticFriction");
+    if (staticFrictionElem && staticFrictionElem->GetText())
+        rigidBody.staticFriction = static_cast<float>(atof(staticFrictionElem->GetText()));
+
+    auto rollingFrictionElem = elem->FirstChildElement("RollingFriction");
+    if (rollingFrictionElem && rollingFrictionElem->GetText())
+        rigidBody.rollingFriction = static_cast<float>(atof(rollingFrictionElem->GetText()));
+
+    auto linearDampingElem = elem->FirstChildElement("LinearDamping");
+    if (linearDampingElem && linearDampingElem->GetText())
+        rigidBody.linearDamping = static_cast<float>(atof(linearDampingElem->GetText()));
+
+    auto angularDampingElem = elem->FirstChildElement("AngularDamping");
+    if (angularDampingElem && angularDampingElem->GetText())
+        rigidBody.angularDamping = static_cast<float>(atof(angularDampingElem->GetText()));
+
+    auto staticElem = elem->FirstChildElement("Static");
+    if (staticElem && staticElem->GetText())
+        rigidBody.isStatic = (strcmp(staticElem->GetText(), "true") == 0);
+
+    // Lets an author start a body already asleep (motionless, no gravity)
+    // rather than waiting for it to settle down naturally - e.g. a stack
+    // placed already at rest, which should stay perfectly still until
+    // actually disturbed instead of drifting through its initial settle.
+    auto sleepingElem = elem->FirstChildElement("Sleeping");
+    if (sleepingElem && sleepingElem->GetText())
+        rigidBody.isSleeping = (strcmp(sleepingElem->GetText(), "true") == 0);
+
+    manager.addComponent(entity, rigidBody);
+    // Every RigidBody needs somewhere for collision resolution to cache its
+    // per-tick momentum contributions; without this the physics system's
+    // hasComponent<EC_DOD_ImpulseAccumulator> check silently drops them.
+    manager.addComponent(entity, EC_DOD_ImpulseAccumulator{});
 }
 
 void EC_DOD_EntityFactory::parseSkybox(TiXmlElement* elem, EntityID entity) {

--- a/src/Entity/EC_DOD_EntityFactory.h
+++ b/src/Entity/EC_DOD_EntityFactory.h
@@ -25,6 +25,10 @@ public:
     const std::vector<EntityID>& getLights() const;
 
     static void parseManifest(TiXmlElement* manifestElem);
+    // Loads a standalone <Manifest> data file (e.g. physics material presets)
+    // independent of any scene, so it's shared across all scenes and can be
+    // edited without a rebuild.
+    static bool loadManifestFile(const std::string& filename);
 
     static TextureManager s_TexManager;
     static ShaderManager s_ShaderManager;
@@ -33,6 +37,10 @@ public:
 
 private:
     struct ShaderPaths { std::string vert; std::string frag; };
+    // Named rigid-body presets (e.g. "Wood", "Rubber") authored once in a
+    // scene's <Manifest> and referenced from <RigidBody material="..."> to
+    // avoid repeating the same mass/restitution numbers across entities.
+    struct PhysicsMaterial { float mass = 1.0f; float restitution = 0.3f; float friction = 0.5f; float staticFriction = 0.5f; float rollingFriction = 0.05f; float linearDamping = 0.01f; float angularDamping = 0.05f; };
 
     glm::vec3 parseVec3(const std::string& text);
     glm::vec4 parseVec4(const std::string& text);
@@ -43,6 +51,7 @@ private:
     void parseLight(TiXmlElement* elem, EntityID entity);
     void parseScript(TiXmlElement* elem, EntityID entity);
     void parseCollider(TiXmlElement* elem, EntityID entity);
+    void parseRigidBody(TiXmlElement* elem, EntityID entity);
     void parseHierarchy(TiXmlElement* elem, EntityID entity);
     void parseSkybox(TiXmlElement* elem, EntityID entity);
     void resolveHierarchyReferences();
@@ -57,5 +66,6 @@ private:
     static std::unordered_map<std::string, ShaderPaths> s_ShaderAliases;
     static std::unordered_map<std::string, std::string> s_ScriptAliases;
     static std::unordered_map<std::string, TiXmlElement*> s_MaterialElements;
+    static std::unordered_map<std::string, PhysicsMaterial> s_PhysicsMaterials;
     static TiXmlDocument s_ManifestDoc;
 };

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -111,6 +111,20 @@ void EC_Game::shutDown()
     m_Messenger.publish(command);
 }
 
+void EC_Game::pauseGame()
+{
+    ECXCommand command;
+    command.type = ECXCommandType::GamePause;
+    m_Messenger.publish(command);
+}
+
+void EC_Game::resumeGame()
+{
+    ECXCommand command;
+    command.type = ECXCommandType::GameResume;
+    m_Messenger.publish(command);
+}
+
 void EC_Game::update(const float& deltaTimeS)
 {
     if (m_Running)

--- a/src/Game.h
+++ b/src/Game.h
@@ -30,6 +30,8 @@ public:
     Game_Error init(const std::string& configurationFilename);
     Game_Error run();
     void shutDown();
+    void pauseGame();
+    void resumeGame();
     void update(const float& deltaTimeS);
     KeyState getKeyState(SDL_Scancode key);
     glm::ivec2 getMousePosition();

--- a/src/Graphics/GL_DebugRenderer.cpp
+++ b/src/Graphics/GL_DebugRenderer.cpp
@@ -1,6 +1,7 @@
 #include "Graphics/GL_DebugRenderer.h"
 #include "Window/Window.h"
 #include "Logging/ECX_Logging.h"
+#include "Engine/Subsystems/CollisionSystems/EC_PairManager.h"
 #include <glm/gtc/matrix_transform.hpp>
 #include <GL/glew.h>
 #include <cmath>
@@ -231,6 +232,30 @@ void GL_DebugRenderer::buildConeLines(const glm::vec3& apex, const glm::vec3& di
     }
 }
 
+void GL_DebugRenderer::buildCrossLines(const glm::vec3& point, float halfSize, std::vector<glm::vec3>& outLines) const
+{
+    outLines.push_back(point - glm::vec3(halfSize, 0.0f, 0.0f));
+    outLines.push_back(point + glm::vec3(halfSize, 0.0f, 0.0f));
+    outLines.push_back(point - glm::vec3(0.0f, halfSize, 0.0f));
+    outLines.push_back(point + glm::vec3(0.0f, halfSize, 0.0f));
+    outLines.push_back(point - glm::vec3(0.0f, 0.0f, halfSize));
+    outLines.push_back(point + glm::vec3(0.0f, 0.0f, halfSize));
+}
+
+void GL_DebugRenderer::renderContactPoints(const glm::mat4& view, const glm::mat4& projection)
+{
+    constexpr float kCrossHalfSize = 0.1f;
+
+    std::vector<glm::vec3> lines;
+    for (const EC_CollisionPair& pair : EC_PairManager::getAllPairs()) {
+        if (!pair.m_Colliding) continue;
+        for (const glm::vec3& point : pair.m_CollisionPoints) {
+            buildCrossLines(point, kCrossHalfSize, lines);
+        }
+    }
+    drawLines(lines, COL_CONTACT, view, projection);
+}
+
 void GL_DebugRenderer::render(const glm::mat4& view, const glm::mat4& projection)
 {
     if (!m_Enabled && !m_HasRay && !m_HasCone) return;
@@ -268,6 +293,8 @@ void GL_DebugRenderer::render(const glm::mat4& view, const glm::mat4& projection
                 break;
             }
         }
+
+        renderContactPoints(view, projection);
     }
 
     if (m_HasRay) {

--- a/src/Graphics/GL_DebugRenderer.h
+++ b/src/Graphics/GL_DebugRenderer.h
@@ -36,6 +36,14 @@ private:
         const EC_DOD_Collider& collider, const EC_DOD_Transform& transform);
     void renderOBB(const glm::mat4& view, const glm::mat4& projection,
         const EC_DOD_Collider& collider, const EC_DOD_Transform& transform);
+    // Draws a small 3-axis cross marker at every contact point of every
+    // currently-colliding pair (EC_PairManager::getAllPairs()) - the same
+    // manifold points EC_PhysicsResolution actually resolves against, so
+    // this is a direct visual check of what the narrow phase is generating
+    // (point count, position, clustering) rather than just the coarse
+    // collider wireframes above. Tied to the same m_Enabled toggle.
+    void renderContactPoints(const glm::mat4& view, const glm::mat4& projection);
+    void buildCrossLines(const glm::vec3& point, float halfSize, std::vector<glm::vec3>& outLines) const;
 
     void buildSphere(float radius, int rings, int sectors);
     void buildBox(const glm::vec3& extents);
@@ -84,4 +92,5 @@ private:
     static constexpr glm::vec4 COL_AABB = glm::vec4(0.0f, 1.0f, 1.0f, 1.0f);
     static constexpr glm::vec4 COL_OBB = glm::vec4(1.0f, 1.0f, 0.0f, 1.0f);
     static constexpr glm::vec4 COL_SPHERE = glm::vec4(1.0f, 0.5f, 0.0f, 1.0f);
+    static constexpr glm::vec4 COL_CONTACT = glm::vec4(1.0f, 0.0f, 0.0f, 1.0f);
 };

--- a/src/Messaging/ECXCommandType.h
+++ b/src/Messaging/ECXCommandType.h
@@ -17,6 +17,7 @@ enum class ECXCommandType
 	GameStart,
 	GameStop,
 	GamePause,
+	GameResume,
 	GameClear,
 	GameLoadSavedState,
 	GameSaveState,

--- a/src/SceneManager/EC_SceneManager.cpp
+++ b/src/SceneManager/EC_SceneManager.cpp
@@ -39,9 +39,12 @@ void EC_SceneManager::init(EC_Game& game, std::string& config, ECXMessenger& mes
     m_Engine.init(m_Settings.engine_settings, game, messenger);
 
     EC_UI_Factory::loadUI(m_Settings.ui_file, messenger);
+    EC_DOD_EntityFactory::loadManifestFile(m_Settings.physics_materials_file);
 
     messenger.Subscribe(*this, ECXCommandType::SystemStart);
     messenger.Subscribe(*this, ECXCommandType::SystemShutdown);
+    messenger.Subscribe(*this, ECXCommandType::GamePause);
+    messenger.Subscribe(*this, ECXCommandType::GameResume);
 
     RenderConfig renderConfig;
     if (!XML::loadRenderConfig(m_Settings.graphics_settings, renderConfig))
@@ -125,6 +128,19 @@ void EC_SceneManager::update(float deltaTimeS, EC_Game& game)
         LOGGING::ECX_Logger::GetInstance()->LogMessage(
             "Load complete!",
             LOGGING::LogLevel::INFORMATION);
+
+        if (!m_InitialPauseDone)
+        {
+            // First scene load has finished - all its entities (and their
+            // Transform components) now exist. Bake a correct initial
+            // transform/camera state once, synchronously, then pause so
+            // that first frame (rather than an identity-matrix/origin frame,
+            // or several seconds of unwatched physics) is what's shown until
+            // the player resumes.
+            m_Engine.stepOnce(1.0f / 60.0f);
+            m_Engine.pause();
+            m_InitialPauseDone = true;
+        }
     }
 
     if (m_Loader->isLoading())
@@ -272,5 +288,13 @@ void EC_SceneManager::receive(ECXCommand& command)
     if (command.type == ECXCommandType::SystemStart)
     {
         m_Engine.start();
+    }
+    if (command.type == ECXCommandType::GamePause)
+    {
+        m_Engine.pause();
+    }
+    if (command.type == ECXCommandType::GameResume)
+    {
+        m_Engine.resume();
     }
 }

--- a/src/SceneManager/EC_SceneManager.h
+++ b/src/SceneManager/EC_SceneManager.h
@@ -54,4 +54,5 @@ private:
     std::unordered_set<size_t> m_LoadingScenes;
     EC_Game* m_Game = nullptr;
     std::mutex m_Lock;
+    bool m_InitialPauseDone = false;
 };

--- a/src/TaskManager/EC_PhysicsThreadTask.cpp
+++ b/src/TaskManager/EC_PhysicsThreadTask.cpp
@@ -20,6 +20,11 @@ void EC_PhysicsThreadTask::addSystem(std::shared_ptr<EC_System> system)
 	m_Systems.push_back(system);
 }
 
+void EC_PhysicsThreadTask::addSubsteppedSystem(std::shared_ptr<EC_System> system)
+{
+	m_SubsteppedSystems.push_back(system);
+}
+
 void EC_PhysicsThreadTask::addGameRef(EC_Game & game)
 {
 	m_game = &game;
@@ -45,6 +50,23 @@ void EC_PhysicsThreadTask::execute()
 				for (auto s : m_Systems)
 				{
 					s->update(m_timestep, *m_game);
+				}
+
+				// Collision + Physics run m_SubstepCount times against a
+				// proportionally smaller timestep instead of once at full
+				// m_timestep - each pass re-detects collisions against
+				// whatever the previous pass just integrated, so a body
+				// mid-topple gets its geometry/impulses refreshed several
+				// times within one visual tick rather than once. See
+				// setSubstepCount's declaration for why this specifically
+				// fixes marginal-equilibrium creep.
+				const float substepDt = m_timestep / static_cast<float>(m_SubstepCount);
+				for (int i = 0; i < m_SubstepCount; i++)
+				{
+					for (auto s : m_SubsteppedSystems)
+					{
+						s->update(substepDt, *m_game);
+					}
 				}
 			}
 			m_accumulator = 0.0f;

--- a/src/TaskManager/EC_PhysicsThreadTask.h
+++ b/src/TaskManager/EC_PhysicsThreadTask.h
@@ -11,16 +11,35 @@ public:
 	EC_PhysicsThreadTask();
 	virtual ~EC_PhysicsThreadTask();
 	void addSystem(std::shared_ptr<EC_System> system);
+	// Collision + Physics only - run once per visual tick isn't enough for
+	// stable stacking (see setSubstepCount below); everything else
+	// (Spatial/Transform/Camera/Scripting) still only needs the once-per-
+	// tick addSystem() above.
+	void addSubsteppedSystem(std::shared_ptr<EC_System> system);
 	void addGameRef(EC_Game& game);
 	void setTimeStep(float timestep);
+	// How many substeps each visual tick's Collision+Physics work is split
+	// into - the standard fix real physics engines (Box2D v3's TGS Soft,
+	// Rapier) use for exactly the kind of slow, marginal-equilibrium creep
+	// a stack shows when a hit only barely destabilizes it: each substep
+	// re-detects collisions against the CURRENT (already-moved-this-tick)
+	// positions and re-solves against a smaller effective timestep, so
+	// gravity/torque integration tracks the true continuous-time dynamics
+	// far more closely than one big low-frequency correction per visual
+	// frame - the discretization error that shows up as "boxes slowly
+	// sliding/dancing before finally toppling" shrinks with the substep
+	// size. Defaults to 1 (no substepping) if never called.
+	void setSubstepCount(int count) { m_SubstepCount = std::max(1, count); }
 
 	// Inherited via EC_Task
 	virtual void execute() override;
 private:
 	std::vector<std::shared_ptr<EC_System>> m_Systems;
+	std::vector<std::shared_ptr<EC_System>> m_SubsteppedSystems;
 	EC_Game* m_game;
 	clock_t m_current_time;
 	float m_timestep;
 	float m_accumulator;
+	int m_SubstepCount = 1;
 };
 

--- a/src/xml/XML.h
+++ b/src/xml/XML.h
@@ -7,6 +7,8 @@
 #include "Graphics/RenderConfig.h"
 #include <string>
 #include <map>
+#include <algorithm>
+#include <cstdlib>
 #include <SDL.h>
 #include "Logging/ECX_Logging.h"
 
@@ -119,10 +121,68 @@ namespace XML
 				{
 					settings.ui_file = child->FirstAttribute()->Value();
 				}
+				else if (strcmp(child->Value(), "PhysicsMaterials") == 0)
+				{
+					settings.physics_materials_file = child->FirstAttribute()->Value();
+				}
 				child = child->NextSiblingElement();
 			}
 			game = game->NextSiblingElement();
 		}
+		return true;
+	}
+
+	// Parses EngineConfig.xml's <Physics><Debug> flags - currently just
+	// LogEnergy (see EC_PhysicsSystem::setLogEnergy). Missing file/section/
+	// tag all quietly default to false rather than failing, since these are
+	// optional debug toggles, not required settings.
+	inline bool loadPhysicsDebugSettings(const std::string& file, bool& outLogEnergy)
+	{
+		outLogEnergy = false;
+
+		TiXmlDocument doc(file.c_str());
+		if (!doc.LoadFile())
+			return false;
+		auto root = doc.FirstChildElement();
+		if (!root)
+			return false;
+
+		auto physics = root->FirstChildElement("Physics");
+		if (!physics)
+			return true;
+		auto debug = physics->FirstChildElement("Debug");
+		if (!debug)
+			return true;
+		auto logEnergy = debug->FirstChildElement("LogEnergy");
+		if (logEnergy && logEnergy->GetText())
+			outLogEnergy = (strcmp(logEnergy->GetText(), "true") == 0);
+
+		return true;
+	}
+
+	// Parses EngineConfig.xml's <Physics><Substeps> - how many times
+	// Collision+Physics re-run per visual tick (see
+	// EC_PhysicsThreadTask::setSubstepCount). Missing file/section/tag
+	// default to 1 (no substepping, original behaviour) rather than
+	// failing.
+	inline bool loadPhysicsSubstepCount(const std::string& file, int& outSubsteps)
+	{
+		outSubsteps = 1;
+
+		TiXmlDocument doc(file.c_str());
+		if (!doc.LoadFile())
+			return false;
+		auto root = doc.FirstChildElement();
+		if (!root)
+			return false;
+
+		auto physics = root->FirstChildElement("Physics");
+		if (!physics)
+			return true;
+		auto substeps = physics->FirstChildElement("Substeps");
+		if (substeps && substeps->GetText())
+			outSubsteps = std::max(1, atoi(substeps->GetText()));
+
 		return true;
 	}
 


### PR DESCRIPTION
Implements real rigid-body physics (gravity, mass, restitution, friction, angular impulses) proven out via a pyramid-of-cubes-vs-ball demo scene, replacing the earlier bone-based approach entirely.

Narrow phase:
- SAT + box-specialized V-Clip (Voronoi-region feature tracking) for OBBVsOBB manifold generation, fixing face/edge misclassification for grossly mismatched body sizes that raw SAT overlap comparison alone gets wrong.

Solver:
- Warm-started sequential impulse resolution with persistent per- contact-point impulse caching.
- Static/kinetic/rolling friction as three genuinely distinct coefficients (Coulomb cone + separate rolling-resistance torque), instead of one coefficient standing in for all three regimes.
- Position correction is translation-only; rotation comes exclusively from the velocity solver so it stays visible to (and stoppable by) the sleep system.
- Collision + Physics now substep (default 4x) within each visual tick - the standard fix (Box2D v3, Rapier) for the slow, unrealistic creep a low-frequency solver shows near a marginal equilibrium.
- Extended sleep-timer window so a slow-building instability isn't mistaken for rest and frozen mid-topple.

Also adds: debug-rendered contact points (F1), a config-driven total- system-energy diagnostic and substep count (EngineConfig.xml), and a scaled-up demo scene (PhysicsDemo.xml, PhysicsMaterials.xml).