### PR TITLE
Fix cubes settling on an edge/corner instead of a face

### DIFF
--- a/src/Components/EC_DOD_Components.h
+++ b/src/Components/EC_DOD_Components.h
@@ -51,6 +51,13 @@ struct EC_DOD_Spatial {
     glm::vec3 direction{ 0.0f, 0.0f, -1.0f };
     glm::vec3 up{ 0.0f, 1.0f, 0.0f };
     glm::vec3 right{ 1.0f, 0.0f, 0.0f };
+    // Real 3-axis rotation state for rigid bodies (see EC_PhysicsSystem's
+    // integration step) - orientation/right/up/direction above are kept in
+    // sync FROM this every physics tick, not the other way round. Bodies
+    // without an EC_DOD_RigidBody (camera, script-driven entities via
+    // EC_SpatialSystem) never touch this field and keep using orientation/
+    // angVelocity directly, same as always.
+    glm::quat orientationQuat{ 1.0f, 0.0f, 0.0f, 0.0f };
 };
 
 struct EC_DOD_RigidBody {

--- a/src/Engine/Subsystems/EC_PhysicsSystem.cpp
+++ b/src/Engine/Subsystems/EC_PhysicsSystem.cpp
@@ -1,10 +1,15 @@
 #include "Engine/Subsystems/EC_PhysicsSystem.h"
 #include "Entity/EC_DOD_EntityManager.h"
+#include "Entity/EC_DOD_Types.h"
 #include "Components/EC_DOD_Components.h"
 #include "Engine/Subsystems/CollisionSystems/EC_PhysicsResolution.h"
 #include "Engine/Subsystems/CollisionSystems/EC_PairManager.h"
 #include "Engine/Subsystems/CollisionSystems/EC_CollisionShapes.h"
 #include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/quaternion.hpp>
+#define GLM_ENABLE_EXPERIMENTAL
+#include <glm/gtx/euler_angles.hpp>
+#include <unordered_map>
 #include "Logging/ECX_Logging.h"
 
 EC_PhysicsSystem::EC_PhysicsSystem() {}
@@ -31,6 +36,84 @@ namespace {
     // enough real time to build up past the threshold before being frozen;
     // Box2D's own default (b2_timeToSleep) is 0.5s for comparison.
     constexpr float kTimeToSleep = 60.0f / 60.0f;
+    // How far (world units, on the ground plane) the body's centre may sit
+    // outside its support base's convex hull and still count as stable -
+    // absorbs numerical noise in the manifold/hull test below, not a real
+    // tolerance for genuine imbalance.
+    constexpr float kStabilityMargin = 0.02f;
+
+    // The velocity-only check above still isn't enough on its own to rule
+    // out the mid-topple case documented above: it only asks "is it moving
+    // right now", not "is this configuration actually stable". A body
+    // resting flat on a face has its centre of mass over the polygon formed
+    // by its contact points; one balanced on an edge or corner does not (its
+    // own weight still exerts a net restoring/toppling torque about that
+    // base). This checks exactly that - true for both a box's multi-point
+    // face manifold and a sphere's single contact point (whose centre sits
+    // directly above it by construction), false for a box balanced on an
+    // edge or vertex - so it gates sleep on genuine geometric stability
+    // rather than an arbitrary point count, without penalising round shapes.
+    // `pts` and `p` are both already projected onto the ground (XZ) plane.
+    bool centerOverSupportBase(const std::vector<glm::vec2>& pts, const glm::vec2& p) {
+        if (pts.empty()) return false;
+
+        std::vector<glm::vec2> unique;
+        for (const glm::vec2& q : pts) {
+            bool dup = false;
+            for (const glm::vec2& u : unique) {
+                if (glm::length(q - u) < 1e-4f) { dup = true; break; }
+            }
+            if (!dup) unique.push_back(q);
+        }
+
+        auto distanceToSegment = [](const glm::vec2& a, const glm::vec2& b, const glm::vec2& pt) {
+            const glm::vec2 ab = b - a;
+            const float denom = std::max(glm::dot(ab, ab), 1e-8f);
+            const float t = std::clamp(glm::dot(pt - a, ab) / denom, 0.0f, 1.0f);
+            return glm::length(pt - (a + t * ab));
+        };
+
+        if (unique.size() == 1) {
+            return glm::length(p - unique[0]) <= kStabilityMargin;
+        }
+        if (unique.size() == 2) {
+            return distanceToSegment(unique[0], unique[1], p) <= kStabilityMargin;
+        }
+
+        // Convex hull via gift wrapping - point counts here are tiny (<= 8).
+        std::vector<glm::vec2> hull;
+        size_t start = 0;
+        for (size_t i = 1; i < unique.size(); ++i) {
+            if (unique[i].x < unique[start].x) start = i;
+        }
+        size_t current = start;
+        do {
+            hull.push_back(unique[current]);
+            size_t next = (current + 1) % unique.size();
+            for (size_t i = 0; i < unique.size(); ++i) {
+                const glm::vec2& a = unique[current];
+                const glm::vec2& b = unique[next];
+                const glm::vec2& c = unique[i];
+                const float cross = (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x);
+                if (cross < 0.0f) next = i;
+            }
+            current = next;
+        } while (current != start && hull.size() <= unique.size());
+
+        if (hull.size() < 3) {
+            return distanceToSegment(hull.front(), hull.back(), p) <= kStabilityMargin;
+        }
+
+        for (size_t i = 0; i < hull.size(); ++i) {
+            const glm::vec2& a = hull[i];
+            const glm::vec2& b = hull[(i + 1) % hull.size()];
+            const glm::vec2 edge = b - a;
+            const glm::vec2 toP = p - a;
+            const float cross = edge.x * toP.y - edge.y * toP.x;
+            if (cross < -kStabilityMargin) return false;
+        }
+        return true;
+    }
 }
 
 void EC_PhysicsSystem::update(const float& deltaTimeS, EC_Game& game) {
@@ -55,6 +138,13 @@ void EC_PhysicsSystem::update(const float& deltaTimeS, EC_Game& game) {
     // (each contact's accumulated impulse persists tick-to-tick instead of
     // restarting at zero every frame), this is the standard sequential-
     // impulse architecture every production physics engine uses.
+    //
+    // Also collected here (independent of the above): every resolvable,
+    // currently-colliding pair's world-space contact points, per entity -
+    // this tick's support base for the centerOverSupportBase() stability
+    // check that gates sleep in Step 2 below.
+    std::unordered_map<EntityID, std::vector<glm::vec3>> bodyContactPoints;
+
     if (m_PairManager) {
         // Warm start every still-colliding, resolvable pair exactly once
         // per tick, before the multi-pass solve below - matches this
@@ -72,6 +162,11 @@ void EC_PhysicsSystem::update(const float& deltaTimeS, EC_Game& game) {
             manifold.contactNormal = pair.m_ContactNormal;
             manifold.penetrationDepth = pair.m_PenetrationDepth;
             EC_PhysicsResolution::warmStartPair(pair.body_A, pair.body_B, manifold, pair.m_ContactCache);
+
+            auto& pointsA = bodyContactPoints[pair.body_A];
+            auto& pointsB = bodyContactPoints[pair.body_B];
+            pointsA.insert(pointsA.end(), pair.m_CollisionPoints.begin(), pair.m_CollisionPoints.end());
+            pointsB.insert(pointsB.end(), pair.m_CollisionPoints.begin(), pair.m_CollisionPoints.end());
         }
 
         constexpr int kSolverPasses = 4;
@@ -169,9 +264,24 @@ void EC_PhysicsSystem::update(const float& deltaTimeS, EC_Game& game) {
         spatial.angVelocity *= std::max(0.0f, 1.0f - rb.angularDamping * deltaTimeS);
 
         // --- Sleep bookkeeping, now that this tick's velocity is final ---
-        const bool atRest =
+        const bool slowEnough =
             glm::dot(spatial.velocity, spatial.velocity) < kSleepLinearThreshold * kSleepLinearThreshold &&
             glm::dot(spatial.angVelocity, spatial.angVelocity) < kSleepAngularThreshold * kSleepAngularThreshold;
+
+        bool stablySupported = false;
+        if (slowEnough) {
+            const auto it = bodyContactPoints.find(entity);
+            if (it != bodyContactPoints.end()) {
+                std::vector<glm::vec2> projected;
+                projected.reserve(it->second.size());
+                for (const glm::vec3& pt : it->second) {
+                    projected.emplace_back(pt.x, pt.z);
+                }
+                stablySupported = centerOverSupportBase(projected, glm::vec2(spatial.position.x, spatial.position.z));
+            }
+        }
+
+        const bool atRest = slowEnough && stablySupported;
         rb.sleepTimer = atRest ? (rb.sleepTimer + deltaTimeS) : 0.0f;
         if (rb.sleepTimer >= kTimeToSleep) {
             rb.isSleeping = true;
@@ -182,20 +292,50 @@ void EC_PhysicsSystem::update(const float& deltaTimeS, EC_Game& game) {
 
         // --- Integrate position/orientation from the final velocity ---
         spatial.position += spatial.velocity * deltaTimeS;
-        spatial.orientation += spatial.angVelocity * deltaTimeS;
 
-        // Rigid bodies can tumble around any axis, so they need a real
-        // 3-axis rotation - built the exact same way
-        // EC_TransformSystem::buildLocal composes the render matrix, so an
-        // OBB collider's orientation always matches what's rendered.
-        glm::mat4 rot(1.0f);
-        rot = glm::rotate(rot, spatial.orientation.x, glm::vec3(1.0f, 0.0f, 0.0f));
-        rot = glm::rotate(rot, spatial.orientation.y, glm::vec3(0.0f, 1.0f, 0.0f));
-        rot = glm::rotate(rot, spatial.orientation.z, glm::vec3(0.0f, 0.0f, 1.0f));
+        // Rigid bodies tumble about a constantly-changing axis, so angular
+        // velocity has to be composed as a real 3D rotation - NOT summed
+        // component-wise into spatial.orientation and rebuilt via three
+        // sequential single-axis rotations (what this used to do, and what
+        // EC_SpatialSystem/EC_TransformSystem::buildLocal still correctly
+        // do for non-physics entities, where only single-axis/no rotation
+        // ever applies). That sequential-Euler reconstruction only tracks
+        // rotation correctly about one fixed axis at a time; a genuine
+        // multi-axis tumble drifts away from the real physical orientation
+        // under it, which is exactly what let a box settle resting on an
+        // edge or corner instead of a face even when the underlying angular
+        // velocity was truly converging toward zero - the DISPLAYED and
+        // COLLIDED orientation was silently wrong regardless.
+        //
+        // Fix: integrate into a real orientation quaternion instead
+        // (spatial.orientationQuat), reading the CURRENT right/up/direction
+        // basis as this tick's starting orientation (so a body's XML-authored
+        // spawn orientation, or last tick's result, is always the true
+        // input - no separate first-tick sync needed), applying this tick's
+        // rotation as a proper quaternion composition, then writing the
+        // result back out to right/up/direction (read by the OBB collider)
+        // AND decomposing it into the same X*Y*Z-order Euler angles
+        // EC_TransformSystem::buildLocal expects, so rendering picks up the
+        // fix automatically without needing any change of its own.
+        const glm::mat3 basis(spatial.right, spatial.up, -spatial.direction);
+        const glm::quat currentQuat = glm::normalize(glm::quat_cast(basis));
 
-        spatial.direction = glm::normalize(glm::vec3(rot * glm::vec4(0.0f, 0.0f, -1.0f, 0.0f)));
-        spatial.up = glm::normalize(glm::vec3(rot * glm::vec4(0.0f, 1.0f, 0.0f, 0.0f)));
-        spatial.right = glm::normalize(glm::vec3(rot * glm::vec4(1.0f, 0.0f, 0.0f, 0.0f)));
+        const float angSpeed = glm::length(spatial.angVelocity);
+        glm::quat deltaQuat(1.0f, 0.0f, 0.0f, 0.0f);
+        if (angSpeed > 1e-8f) {
+            // World-space angular velocity - premultiply.
+            deltaQuat = glm::angleAxis(angSpeed * deltaTimeS, spatial.angVelocity / angSpeed);
+        }
+        const glm::quat newQuat = glm::normalize(deltaQuat * currentQuat);
+        spatial.orientationQuat = newQuat;
+
+        const glm::mat3 newBasis = glm::mat3_cast(newQuat);
+        spatial.right = glm::normalize(newBasis[0]);
+        spatial.up = glm::normalize(newBasis[1]);
+        spatial.direction = glm::normalize(-newBasis[2]);
+
+        glm::extractEulerAngleXYZ(glm::mat4(newBasis),
+            spatial.orientation.x, spatial.orientation.y, spatial.orientation.z);
     }
 
     // Total system mechanical energy (kinetic + gravitational potential, not


### PR DESCRIPTION
Angular velocity was integrated by summing it into a Euler-angle vector and rebuilding the rotation via three sequential fixed-axis rotations, which only tracks rotation correctly about one fixed axis
- a genuinely tumbling body drifts to the wrong final orientation under that scheme. Replaced with proper quaternion integration (orientationQuat), then derive right/up/direction and orientation's Euler angles from it so the OBB collider and render transform both pick up the fix without changes of their own.

Also gate sleep on the body's centre of mass actually projecting over its contact-point support base, not just low velocity, so a body balanced on an edge/corner never freezes there mid-topple.