### PR TITLE
Add Catch2 unit tests for collision/spatial math and CI workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,38 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    branches: [ develop ]
+  push:
+    branches: [ develop ]
+
+jobs:
+  unit-tests:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Only glm + Catch2 are needed here (see CMakeLists.txt's ECX_BUILD_ENGINE
+      # option) - the full engine's SDL2/GLEW/assimp/Lua/OpenGL/Stb toolchain is
+      # skipped entirely so this stays fast. windows-latest ships vcpkg
+      # pre-installed at C:\vcpkg, matching the toolchain file CMakeLists.txt
+      # already points at.
+      - name: Cache vcpkg binary cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.LOCALAPPDATA }}\vcpkg\archives
+          key: vcpkg-archives-x64-windows-glm-catch2-v1
+
+      - name: Install dependencies (glm, Catch2)
+        run: C:\vcpkg\vcpkg.exe install glm:x64-windows catch2:x64-windows
+
+      - name: Configure (tests only, engine build skipped)
+        run: cmake -S . -B build -DECX_BUILD_ENGINE=OFF
+
+      - name: Build ECX_UnitTests
+        run: cmake --build build --config Debug --target ECX_UnitTests
+
+      - name: Run tests
+        run: .\build\Debug\ECX_UnitTests.exe

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -35,4 +35,4 @@ jobs:
         run: cmake --build build --config Debug --target ECX_UnitTests
 
       - name: Run tests
-        run: .\build\Debug\ECX_UnitTests.exe
+        run: .\build\Debug\ECX_UnitTests.exe --success --durations yes -v high

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,18 @@ project(ECX LANGUAGES CXX)
 
 set(SOURCE_DIR ${PROJECT_SOURCE_DIR}/src)
 
+# Off in CI (unit-test workflow): skips the main ECX target and its heavy
+# SDL2/GLEW/assimp/Lua/OpenGL/Stb dependencies entirely, so `cmake --build
+# --target ECX_UnitTests` only needs glm + Catch2 to configure.
+option(ECX_BUILD_ENGINE "Build the main ECX game target (requires SDL2/GLEW/assimp/Lua/OpenGL/Stb)" ON)
 
 set(CMAKE_GENERATOR_PLATFORM x64)
 set(CMAKE_BUILD_TYPE Debug)
+
+find_package(GLM CONFIG REQUIRED)
+find_package(Catch2 CONFIG REQUIRED)
+
+if(ECX_BUILD_ENGINE)
 
 message("searching ${SOURCE_DIR} for source files")
 
@@ -31,7 +40,6 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DLOG_ENABLED")
 find_package(SDL2 CONFIG REQUIRED)
 find_package(SDL2_image CONFIG REQUIRED)
 find_package(GLEW CONFIG REQUIRED)
-find_package(GLM CONFIG REQUIRED)
 find_package(assimp CONFIG REQUIRED)
 find_package(Lua REQUIRED)
 find_package(OpenGL REQUIRED)
@@ -132,14 +140,29 @@ add_custom_command(
                 ${CMAKE_CURRENT_BINARY_DIR}/data
         COMMENT "Copying data files...")
 
-# Standalone unit tests for the GJK collision math (Issues #30/#29) - deliberately
-# isolated from the main ECX target: only depends on glm, not SDL/GLEW/assimp/Lua/the
-# ECS, so it builds fast and can run headless without a graphics context.
-add_executable(ECX_GJK_Tests
+endif() # ECX_BUILD_ENGINE
+
+# Catch2-based unit tests for the pure-logic collision/spatial modules (Tier 1 of
+# the testability review): GJK/ConvexSupport, CollisionChecks, VClip, PairManager,
+# SpatialGrid, Frustum. Deliberately isolated from the main ECX target: only
+# depends on glm + Catch2, not SDL/GLEW/assimp/Lua/the ECS, so it builds fast and
+# can run headless without a graphics context.
+
+add_executable(ECX_UnitTests
     tests/EC_GJK_Tests.cpp
+    tests/EC_CollisionChecks_Tests.cpp
+    tests/EC_VClip_Tests.cpp
+    tests/EC_PairManager_Tests.cpp
+    tests/EC_SpatialGrid_Tests.cpp
+    tests/EC_Frustum_Tests.cpp
     src/Engine/Subsystems/CollisionSystems/EC_GJK.cpp
     src/Engine/Subsystems/CollisionSystems/EC_ConvexSupport.cpp
+    src/Engine/Subsystems/CollisionSystems/EC_CollisionChecks.cpp
+    src/Engine/Subsystems/CollisionSystems/EC_VClip.cpp
+    src/Engine/Subsystems/CollisionSystems/EC_PairManager.cpp
+    src/Spatial/EC_SpatialGrid.cpp
+    src/Spatial/EC_Frustum.cpp
 )
-set_property(TARGET ECX_GJK_Tests PROPERTY CXX_STANDARD 17)
-target_include_directories(ECX_GJK_Tests PRIVATE ${SOURCE_DIR} glm::glm)
-target_link_libraries(ECX_GJK_Tests glm::glm)
+set_property(TARGET ECX_UnitTests PROPERTY CXX_STANDARD 17)
+target_include_directories(ECX_UnitTests PRIVATE ${SOURCE_DIR})
+target_link_libraries(ECX_UnitTests PRIVATE glm::glm Catch2::Catch2WithMain)

--- a/tests/EC_CollisionChecks_Tests.cpp
+++ b/tests/EC_CollisionChecks_Tests.cpp
@@ -1,0 +1,132 @@
+// Unit tests for the pure narrow-phase shape-vs-shape tests (Tier 1 of the
+// testability review): no engine/entity/GL dependency, only glm + the shape
+// structs themselves.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include "Engine/Subsystems/CollisionSystems/EC_CollisionChecks.h"
+
+using Catch::Matchers::WithinAbs;
+
+namespace {
+    constexpr float kTol = 1e-4f;
+}
+
+TEST_CASE("SphereVsSphere detects overlap and reports separation-based manifold", "[CollisionChecks][Sphere]") {
+    Sphere a{ glm::vec3(0.0f), 1.0f };
+    Sphere b{ glm::vec3(0.0f), 1.0f };
+    CollisionManifold manifold;
+
+    SECTION("overlapping spheres collide, normal points A->B, penetration positive") {
+        bool hit = EC_CollisionChecks::SphereVsSphere(a, glm::vec3(0.0f), b, glm::vec3(1.5f, 0.0f, 0.0f), manifold);
+        REQUIRE(hit);
+        REQUIRE_THAT(manifold.contactNormal.x, WithinAbs(1.0f, kTol));
+        REQUIRE_THAT(manifold.penetrationDepth, WithinAbs(0.5f, kTol));
+        REQUIRE(manifold.contactPoints.size() == 1);
+    }
+
+    SECTION("spheres exactly touching (zero penetration) still register as colliding") {
+        bool hit = EC_CollisionChecks::SphereVsSphere(a, glm::vec3(0.0f), b, glm::vec3(2.0f, 0.0f, 0.0f), manifold);
+        REQUIRE(hit);
+        REQUIRE_THAT(manifold.penetrationDepth, WithinAbs(0.0f, kTol));
+    }
+
+    SECTION("spheres far apart do not collide") {
+        bool hit = EC_CollisionChecks::SphereVsSphere(a, glm::vec3(0.0f), b, glm::vec3(5.0f, 0.0f, 0.0f), manifold);
+        REQUIRE_FALSE(hit);
+    }
+}
+
+TEST_CASE("AABBVsAABB picks the minimum-penetration axis and orients A->B", "[CollisionChecks][AABB]") {
+    AABB a{ glm::vec3(-1.0f), glm::vec3(1.0f) };
+    AABB b{ glm::vec3(-1.0f), glm::vec3(1.0f) };
+    CollisionManifold manifold;
+
+    SECTION("shallow overlap on X picks X as the separating axis") {
+        // A at origin, B shifted 1.5 on X: overlap on X = 0.5, Y/Z fully overlap (2.0)
+        bool hit = EC_CollisionChecks::AABBVsAABB(a, glm::vec3(0.0f), b, glm::vec3(1.5f, 0.0f, 0.0f), manifold);
+        REQUIRE(hit);
+        REQUIRE_THAT(manifold.contactNormal.x, WithinAbs(1.0f, kTol));
+        REQUIRE_THAT(manifold.penetrationDepth, WithinAbs(0.5f, kTol));
+        REQUIRE(manifold.contactPoints.size() == 4);
+    }
+
+    SECTION("shallow overlap on Y picks Y and produces a horizontal 4-point face") {
+        bool hit = EC_CollisionChecks::AABBVsAABB(a, glm::vec3(0.0f), b, glm::vec3(0.0f, 1.5f, 0.0f), manifold);
+        REQUIRE(hit);
+        REQUIRE_THAT(manifold.contactNormal.y, WithinAbs(1.0f, kTol));
+        REQUIRE_THAT(manifold.penetrationDepth, WithinAbs(0.5f, kTol));
+    }
+
+    SECTION("non-overlapping boxes do not collide") {
+        bool hit = EC_CollisionChecks::AABBVsAABB(a, glm::vec3(0.0f), b, glm::vec3(10.0f, 0.0f, 0.0f), manifold);
+        REQUIRE_FALSE(hit);
+    }
+}
+
+TEST_CASE("SphereVsAABB reports the AABB surface point closest to the sphere center", "[CollisionChecks][SphereAABB]") {
+    AABB box{ glm::vec3(-1.0f), glm::vec3(1.0f) };
+    CollisionManifold manifold;
+
+    SECTION("sphere overlapping a face") {
+        Sphere s{ glm::vec3(0.0f), 0.5f };
+        bool hit = EC_CollisionChecks::SphereVsAABB(s, glm::vec3(1.3f, 0.0f, 0.0f), box, glm::vec3(0.0f), manifold);
+        REQUIRE(hit);
+        REQUIRE_THAT(manifold.contactPoints[0].x, WithinAbs(1.0f, kTol));
+        REQUIRE_THAT(manifold.contactNormal.x, WithinAbs(1.0f, kTol));
+    }
+
+    SECTION("sphere fully outside the AABB's influence does not collide") {
+        Sphere s{ glm::vec3(0.0f), 0.5f };
+        bool hit = EC_CollisionChecks::SphereVsAABB(s, glm::vec3(5.0f, 0.0f, 0.0f), box, glm::vec3(0.0f), manifold);
+        REQUIRE_FALSE(hit);
+    }
+
+    SECTION("sphere center inside the box still resolves (zero-distance fallback normal)") {
+        Sphere s{ glm::vec3(0.0f), 0.5f };
+        bool hit = EC_CollisionChecks::SphereVsAABB(s, glm::vec3(0.0f), box, glm::vec3(0.0f), manifold);
+        REQUIRE(hit);
+        REQUIRE_THAT(manifold.contactNormal.y, WithinAbs(1.0f, kTol));
+    }
+}
+
+TEST_CASE("OBBVsOBB axis-aligned boxes behave like AABBVsAABB (identity orientation)", "[CollisionChecks][OBB]") {
+    OBB a{ glm::vec3(0.0f), glm::vec3(1.0f), glm::mat3(1.0f) };
+    OBB b{ glm::vec3(0.0f), glm::vec3(1.0f), glm::mat3(1.0f) };
+    CollisionManifold manifold;
+
+    SECTION("shallow overlap along X separates on X with correct depth") {
+        bool hit = EC_CollisionChecks::OBBVsOBB(a, glm::vec3(0.0f), b, glm::vec3(1.5f, 0.0f, 0.0f), manifold);
+        REQUIRE(hit);
+        REQUIRE_THAT(std::abs(manifold.contactNormal.x), WithinAbs(1.0f, kTol));
+        REQUIRE_THAT(manifold.penetrationDepth, WithinAbs(0.5f, kTol));
+    }
+
+    SECTION("separated boxes report no collision") {
+        bool hit = EC_CollisionChecks::OBBVsOBB(a, glm::vec3(0.0f), b, glm::vec3(10.0f, 0.0f, 0.0f), manifold);
+        REQUIRE_FALSE(hit);
+    }
+}
+
+TEST_CASE("FrustumVsAABB conservative sphere-bound test", "[CollisionChecks][Frustum]") {
+    Frustum f{};
+    f.position = glm::vec3(0.0f);
+    f.direction = glm::vec3(0.0f, 0.0f, -1.0f);
+    f.up = glm::vec3(0.0f, 1.0f, 0.0f);
+    f.right = glm::vec3(1.0f, 0.0f, 0.0f);
+    f.nearPlane = 0.1f;
+    f.farPlane = 100.0f;
+    f.fov = 60.0f;
+    f.aspectRatio = 16.0f / 9.0f;
+
+    AABB box{ glm::vec3(-1.0f), glm::vec3(1.0f) };
+
+    SECTION("box near the frustum center is considered visible") {
+        bool visible = EC_CollisionChecks::FrustumVsAABB(f, glm::vec3(0.0f), box, glm::vec3(0.0f, 0.0f, -50.0f));
+        REQUIRE(visible);
+    }
+
+    SECTION("box far outside the frustum's bounding sphere is culled") {
+        bool visible = EC_CollisionChecks::FrustumVsAABB(f, glm::vec3(0.0f), box, glm::vec3(0.0f, 0.0f, 10000.0f));
+        REQUIRE_FALSE(visible);
+    }
+}

--- a/tests/EC_Frustum_Tests.cpp
+++ b/tests/EC_Frustum_Tests.cpp
@@ -1,0 +1,45 @@
+// Unit tests for EC_Frustum plane extraction + AABB culling. Pure glm, no
+// engine/GL dependency (view/projection matrices are built by hand here rather
+// than pulled from a live camera).
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include "Spatial/EC_Frustum.h"
+
+using Catch::Matchers::WithinAbs;
+
+namespace {
+    glm::mat4 standardViewProjection() {
+        glm::mat4 view = glm::lookAt(glm::vec3(0.0f, 0.0f, 5.0f), glm::vec3(0.0f, 0.0f, 0.0f), glm::vec3(0.0f, 1.0f, 0.0f));
+        glm::mat4 proj = glm::perspective(glm::radians(60.0f), 16.0f / 9.0f, 0.1f, 100.0f);
+        return proj * view;
+    }
+}
+
+TEST_CASE("extractPlanes produces 6 unit-length plane normals", "[Frustum]") {
+    auto planes = EC_Frustum::extractPlanes(standardViewProjection());
+    for (const auto& p : planes) {
+        REQUIRE_THAT(glm::length(p.normal), WithinAbs(1.0f, 1e-3f));
+    }
+}
+
+TEST_CASE("intersectsAABB keeps a box centered in front of the camera", "[Frustum]") {
+    auto planes = EC_Frustum::extractPlanes(standardViewProjection());
+    AABB box{ glm::vec3(-1.0f, -1.0f, -1.0f), glm::vec3(1.0f, 1.0f, 1.0f) };
+
+    REQUIRE(EC_Frustum::intersectsAABB(planes, box));
+}
+
+TEST_CASE("intersectsAABB culls a box far behind the camera (outside the near/far range)", "[Frustum]") {
+    auto planes = EC_Frustum::extractPlanes(standardViewProjection());
+    AABB box{ glm::vec3(-1.0f, -1.0f, 999.0f), glm::vec3(1.0f, 1.0f, 1001.0f) };
+
+    REQUIRE_FALSE(EC_Frustum::intersectsAABB(planes, box));
+}
+
+TEST_CASE("intersectsAABB culls a box far outside the left/right side planes", "[Frustum]") {
+    auto planes = EC_Frustum::extractPlanes(standardViewProjection());
+    AABB box{ glm::vec3(500.0f, -1.0f, -1.0f), glm::vec3(501.0f, 1.0f, 1.0f) };
+
+    REQUIRE_FALSE(EC_Frustum::intersectsAABB(planes, box));
+}

--- a/tests/EC_GJK_Tests.cpp
+++ b/tests/EC_GJK_Tests.cpp
@@ -1,38 +1,16 @@
-// Standalone unit tests for EC_GJK / EC_ConvexSupport (Issues #30/#29), isolated from
-// the engine (no SDL/OpenGL/ECS/Lua dependency - just glm). Build/run via the
-// ECX_GJK_Tests CMake target. No test framework dependency - plain CHECK() macro
-// tracking pass/fail counts, non-zero exit code on any failure.
+// Unit tests for EC_GJK / EC_ConvexSupport (Issues #30/#29), isolated from the
+// engine (no SDL/OpenGL/ECS/Lua dependency - just glm). Part of the ECX_UnitTests
+// Catch2 target.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include "Engine/Subsystems/CollisionSystems/EC_GJK.h"
 #include "Engine/Subsystems/CollisionSystems/EC_ConvexSupport.h"
 #include <glm/gtc/matrix_transform.hpp>
-#include <cstdio>
 #include <cmath>
 
-namespace
-{
-    int g_passed = 0;
-    int g_failed = 0;
+using Catch::Matchers::WithinAbs;
 
-    void check(bool condition, const char* description)
-    {
-        if (condition) {
-            g_passed++;
-        } else {
-            g_failed++;
-            std::printf("FAIL: %s\n", description);
-        }
-    }
-
-    void checkNear(float actual, float expected, float tolerance, const char* description)
-    {
-        check(std::abs(actual - expected) <= tolerance, description);
-    }
-
-    void checkNear(const glm::vec3& actual, const glm::vec3& expected, float tolerance, const char* description)
-    {
-        check(glm::length(actual - expected) <= tolerance, description);
-    }
-
+namespace {
     using namespace EC_ConvexSupport;
 
     EC_GJK::SupportFn sphereFn(const glm::vec3& c, float r)
@@ -62,172 +40,162 @@ namespace
         };
     }
 
-    void test_intersects_sphere_sphere()
+    void checkNear(const glm::vec3& actual, const glm::vec3& expected, float tolerance)
     {
-        check(EC_GJK::intersects(sphereFn({ 0, 0, 0 }, 1.0f), sphereFn({ 1.5f, 0, 0 }, 1.0f)),
-            "sphere-sphere: overlapping (dist 1.5, radii 1+1) should intersect");
-        check(!EC_GJK::intersects(sphereFn({ 0, 0, 0 }, 1.0f), sphereFn({ 3.0f, 0, 0 }, 1.0f)),
-            "sphere-sphere: separated (dist 3, radii 1+1) should not intersect");
-    }
-
-    void test_intersects_box_box()
-    {
-        glm::mat3 identity(1.0f);
-        check(EC_GJK::intersects(
-            boxFn({ 0, 0, 0 }, { 1, 1, 1 }, identity),
-            boxFn({ 1.5f, 0, 0 }, { 1, 1, 1 }, identity)),
-            "box-box: overlapping (dist 1.5, half-extents 1+1) should intersect");
-        check(!EC_GJK::intersects(
-            boxFn({ 0, 0, 0 }, { 1, 1, 1 }, identity),
-            boxFn({ 3.0f, 0, 0 }, { 1, 1, 1 }, identity)),
-            "box-box: separated (dist 3, half-extents 1+1) should not intersect");
-    }
-
-    void test_intersects_obb_aabb()
-    {
-        glm::mat3 identity(1.0f);
-        glm::mat3 rot45 = glm::mat3(glm::rotate(glm::mat4(1.0f), glm::radians(45.0f), glm::vec3(0, 1, 0)));
-        // Box rotated 45deg around Y with half-extents (1,1,1) reaches ~1.41421 along
-        // world X (cos45 + sin45). Combined with the AABB's own 1.0 half-extent, the
-        // overlap threshold along X is ~2.41421.
-        check(EC_GJK::intersects(
-            boxFn({ 0, 0, 0 }, { 1, 1, 1 }, identity),
-            boxFn({ 1.8f, 0, 0 }, { 1, 1, 1 }, rot45)),
-            "obb-aabb: overlapping (dist 1.8 < ~2.414 reach) should intersect");
-        check(!EC_GJK::intersects(
-            boxFn({ 0, 0, 0 }, { 1, 1, 1 }, identity),
-            boxFn({ 3.5f, 0, 0 }, { 1, 1, 1 }, rot45)),
-            "obb-aabb: separated (dist 3.5 > ~2.414 reach) should not intersect");
-    }
-
-    void test_intersects_cone_sphere()
-    {
-        glm::vec3 apex(0, 0, 0), axis(0, 0, 1);
-        float halfAngle = glm::radians(20.0f);
-        float height = 50.0f;
-
-        check(EC_GJK::intersects(coneFn(apex, axis, halfAngle, height), sphereFn({ 0, 0, 10 }, 1.0f)),
-            "cone-sphere: dead ahead, unobstructed should intersect");
-
-        // 45deg off-axis, small radius - well outside a 20deg cone.
-        glm::vec3 offAxisPos = glm::vec3(std::sin(glm::radians(45.0f)), 0, std::cos(glm::radians(45.0f))) * 10.0f;
-        check(!EC_GJK::intersects(coneFn(apex, axis, halfAngle, height), sphereFn(offAxisPos, 1.0f)),
-            "cone-sphere: 45deg off-axis, outside 20deg cone should not intersect");
-
-        // Center at ~24.2deg (outside a 20deg cone) but radius 2 large enough that its
-        // near edge dips inside the cone's ~3.64-radius cross-section at that depth -
-        // this is the "partially hit should be collected" case.
-        glm::vec3 partialPos(4.5f, 0, 10.0f);
-        check(EC_GJK::intersects(coneFn(apex, axis, halfAngle, height), sphereFn(partialPos, 2.0f)),
-            "cone-sphere: center outside angle but radius overlaps cone edge should intersect");
-    }
-
-    void test_intersects_cone_box()
-    {
-        // Reproduces the reported bug: a box whose center is outside the cone's angle
-        // but whose near corner pokes inside it.
-        glm::vec3 apex(0, 0, 0), axis(0, 0, 1);
-        float halfAngle = glm::radians(20.0f);
-        float height = 50.0f;
-        glm::mat3 identity(1.0f);
-
-        // Box center (5,0,10) is at atan(5/10)=26.57deg (outside 20deg), but its near
-        // corner at x=5-2=3 is at atan(3/10)=16.7deg (inside 20deg).
-        check(EC_GJK::intersects(coneFn(apex, axis, halfAngle, height),
-            boxFn({ 5, 0, 10 }, { 2, 2, 2 }, identity)),
-            "cone-box: center outside angle, near corner inside cone should intersect");
-
-        // Box entirely outside even at its nearest corner (x=9, atan(9/10)=41.9deg).
-        check(!EC_GJK::intersects(coneFn(apex, axis, halfAngle, height),
-            boxFn({ 10, 0, 10 }, { 1, 1, 1 }, identity)),
-            "cone-box: entirely outside cone angle (including near corner) should not intersect");
-    }
-
-    void test_raycast_sphere()
-    {
-        float t; glm::vec3 n;
-        bool hit = EC_GJK::raycast({ -10, 0, 0 }, { 1, 0, 0 }, 100.0f, sphereFn({ 0, 0, 0 }, 2.0f), t, n);
-        check(hit, "raycast-sphere: should hit");
-        checkNear(t, 8.0f, 0.01f, "raycast-sphere: distance should be 8 (origin -10, surface at -2)");
-        checkNear(n, { -1, 0, 0 }, 0.01f, "raycast-sphere: normal should point back toward origin");
-
-        bool miss = EC_GJK::raycast({ -10, 5, 0 }, { 1, 0, 0 }, 100.0f, sphereFn({ 0, 0, 0 }, 2.0f), t, n);
-        check(!miss, "raycast-sphere: ray offset beyond radius should miss");
-    }
-
-    void test_raycast_aabb()
-    {
-        float t; glm::vec3 n;
-        glm::mat3 identity(1.0f);
-        bool hit = EC_GJK::raycast({ -10, 0, 0 }, { 1, 0, 0 }, 100.0f,
-            boxFn({ 0, 0, 0 }, { 1, 1, 1 }, identity), t, n);
-        check(hit, "raycast-aabb: should hit");
-        checkNear(t, 9.0f, 0.01f, "raycast-aabb: distance should be 9 (origin -10, face at -1)");
-
-        bool miss = EC_GJK::raycast({ -10, 5, 0 }, { 1, 0, 0 }, 100.0f,
-            boxFn({ 0, 0, 0 }, { 1, 1, 1 }, identity), t, n);
-        check(!miss, "raycast-aabb: ray offset beyond extents should miss");
-    }
-
-    void test_raycast_obb()
-    {
-        float t; glm::vec3 n;
-        glm::mat3 rot45 = glm::mat3(glm::rotate(glm::mat4(1.0f), glm::radians(45.0f), glm::vec3(0, 1, 0)));
-        bool hit = EC_GJK::raycast({ -10, 0, 0 }, { 1, 0, 0 }, 100.0f,
-            boxFn({ 0, 0, 0 }, { 1, 1, 1 }, rot45), t, n);
-        check(hit, "raycast-obb: should hit");
-        // Reach along X for a 45deg-rotated unit-half-extent box is cos45+sin45 ~= 1.41421.
-        checkNear(t, 10.0f - 1.41421f, 0.02f, "raycast-obb: distance should account for rotated silhouette");
-    }
-
-    void test_raycast_capsule()
-    {
-        float t; glm::vec3 n;
-        glm::vec3 a(0, -2, 0), b(0, 2, 0);
-
-        // Through the cylindrical body.
-        bool hitBody = EC_GJK::raycast({ -10, 0, 0 }, { 1, 0, 0 }, 100.0f, capsuleFn(a, b, 1.0f), t, n);
-        check(hitBody, "raycast-capsule: body hit should succeed");
-        checkNear(t, 9.0f, 0.01f, "raycast-capsule: body hit distance should be 9");
-
-        // Through the rounded top cap only - capsule axis runs along Y, so "above the
-        // straight segment" means offsetting Y past b.y=2, not Z.
-        bool hitCap = EC_GJK::raycast({ -10, 2.5f, 0 }, { 1, 0, 0 }, 100.0f, capsuleFn(a, b, 1.0f), t, n);
-        check(hitCap, "raycast-capsule: cap hit should succeed");
-        checkNear(t, 9.134f, 0.05f, "raycast-capsule: cap hit distance should be ~9.134");
-    }
-
-    void test_raycast_cylinder()
-    {
-        float t; glm::vec3 n;
-        glm::vec3 a(0, -2, 0), b(0, 2, 0);
-
-        // Straight up through the flat bottom cap.
-        bool hitCap = EC_GJK::raycast({ 0, -10, 0 }, { 0, 1, 0 }, 100.0f, cylinderFn(a, b, 1.0f), t, n);
-        check(hitCap, "raycast-cylinder: flat cap hit should succeed");
-        checkNear(t, 8.0f, 0.01f, "raycast-cylinder: flat cap hit distance should be 8");
-        checkNear(n, { 0, -1, 0 }, 0.01f, "raycast-cylinder: flat cap normal should face down");
-
-        // Through the round side.
-        bool hitBody = EC_GJK::raycast({ -10, 0, 0 }, { 1, 0, 0 }, 100.0f, cylinderFn(a, b, 1.0f), t, n);
-        check(hitBody, "raycast-cylinder: body hit should succeed");
-        checkNear(t, 9.0f, 0.01f, "raycast-cylinder: body hit distance should be 9");
+        REQUIRE(glm::length(actual - expected) <= tolerance);
     }
 }
 
-int main()
-{
-    test_intersects_sphere_sphere();
-    test_intersects_box_box();
-    test_intersects_obb_aabb();
-    test_intersects_cone_sphere();
-    test_intersects_cone_box();
-    test_raycast_sphere();
-    test_raycast_aabb();
-    test_raycast_obb();
-    test_raycast_capsule();
-    test_raycast_cylinder();
+TEST_CASE("GJK intersects: sphere vs sphere", "[GJK]") {
+    REQUIRE(EC_GJK::intersects(sphereFn({ 0, 0, 0 }, 1.0f), sphereFn({ 1.5f, 0, 0 }, 1.0f)));
+    REQUIRE_FALSE(EC_GJK::intersects(sphereFn({ 0, 0, 0 }, 1.0f), sphereFn({ 3.0f, 0, 0 }, 1.0f)));
+}
 
-    std::printf("\n%d passed, %d failed\n", g_passed, g_failed);
-    return g_failed == 0 ? 0 : 1;
+TEST_CASE("GJK intersects: box vs box", "[GJK]") {
+    glm::mat3 identity(1.0f);
+    REQUIRE(EC_GJK::intersects(
+        boxFn({ 0, 0, 0 }, { 1, 1, 1 }, identity),
+        boxFn({ 1.5f, 0, 0 }, { 1, 1, 1 }, identity)));
+    REQUIRE_FALSE(EC_GJK::intersects(
+        boxFn({ 0, 0, 0 }, { 1, 1, 1 }, identity),
+        boxFn({ 3.0f, 0, 0 }, { 1, 1, 1 }, identity)));
+}
+
+TEST_CASE("GJK intersects: OBB vs AABB", "[GJK]") {
+    glm::mat3 identity(1.0f);
+    glm::mat3 rot45 = glm::mat3(glm::rotate(glm::mat4(1.0f), glm::radians(45.0f), glm::vec3(0, 1, 0)));
+    // Box rotated 45deg around Y with half-extents (1,1,1) reaches ~1.41421 along
+    // world X (cos45 + sin45). Combined with the AABB's own 1.0 half-extent, the
+    // overlap threshold along X is ~2.41421.
+    REQUIRE(EC_GJK::intersects(
+        boxFn({ 0, 0, 0 }, { 1, 1, 1 }, identity),
+        boxFn({ 1.8f, 0, 0 }, { 1, 1, 1 }, rot45)));
+    REQUIRE_FALSE(EC_GJK::intersects(
+        boxFn({ 0, 0, 0 }, { 1, 1, 1 }, identity),
+        boxFn({ 3.5f, 0, 0 }, { 1, 1, 1 }, rot45)));
+}
+
+TEST_CASE("GJK intersects: cone vs sphere", "[GJK]") {
+    glm::vec3 apex(0, 0, 0), axis(0, 0, 1);
+    float halfAngle = glm::radians(20.0f);
+    float height = 50.0f;
+
+    SECTION("dead ahead, unobstructed") {
+        REQUIRE(EC_GJK::intersects(coneFn(apex, axis, halfAngle, height), sphereFn({ 0, 0, 10 }, 1.0f)));
+    }
+
+    SECTION("45deg off-axis, small radius - well outside a 20deg cone") {
+        glm::vec3 offAxisPos = glm::vec3(std::sin(glm::radians(45.0f)), 0, std::cos(glm::radians(45.0f))) * 10.0f;
+        REQUIRE_FALSE(EC_GJK::intersects(coneFn(apex, axis, halfAngle, height), sphereFn(offAxisPos, 1.0f)));
+    }
+
+    SECTION("center outside angle but radius overlaps cone edge") {
+        // Center at ~24.2deg (outside a 20deg cone) but radius 2 large enough that its
+        // near edge dips inside the cone's ~3.64-radius cross-section at that depth.
+        glm::vec3 partialPos(4.5f, 0, 10.0f);
+        REQUIRE(EC_GJK::intersects(coneFn(apex, axis, halfAngle, height), sphereFn(partialPos, 2.0f)));
+    }
+}
+
+TEST_CASE("GJK intersects: cone vs box", "[GJK]") {
+    // Reproduces the reported bug: a box whose center is outside the cone's angle
+    // but whose near corner pokes inside it.
+    glm::vec3 apex(0, 0, 0), axis(0, 0, 1);
+    float halfAngle = glm::radians(20.0f);
+    float height = 50.0f;
+    glm::mat3 identity(1.0f);
+
+    SECTION("center outside angle, near corner inside cone") {
+        // Box center (5,0,10) is at atan(5/10)=26.57deg (outside 20deg), but its near
+        // corner at x=5-2=3 is at atan(3/10)=16.7deg (inside 20deg).
+        REQUIRE(EC_GJK::intersects(coneFn(apex, axis, halfAngle, height),
+            boxFn({ 5, 0, 10 }, { 2, 2, 2 }, identity)));
+    }
+
+    SECTION("entirely outside cone angle, including near corner") {
+        // Box entirely outside even at its nearest corner (x=9, atan(9/10)=41.9deg).
+        REQUIRE_FALSE(EC_GJK::intersects(coneFn(apex, axis, halfAngle, height),
+            boxFn({ 10, 0, 10 }, { 1, 1, 1 }, identity)));
+    }
+}
+
+TEST_CASE("GJK raycast: sphere", "[GJK][raycast]") {
+    float t; glm::vec3 n;
+
+    SECTION("hits, distance and normal are correct") {
+        bool hit = EC_GJK::raycast({ -10, 0, 0 }, { 1, 0, 0 }, 100.0f, sphereFn({ 0, 0, 0 }, 2.0f), t, n);
+        REQUIRE(hit);
+        REQUIRE_THAT(t, WithinAbs(8.0f, 0.01f)); // origin -10, surface at -2
+        checkNear(n, { -1, 0, 0 }, 0.01f);
+    }
+
+    SECTION("ray offset beyond radius misses") {
+        bool miss = EC_GJK::raycast({ -10, 5, 0 }, { 1, 0, 0 }, 100.0f, sphereFn({ 0, 0, 0 }, 2.0f), t, n);
+        REQUIRE_FALSE(miss);
+    }
+}
+
+TEST_CASE("GJK raycast: AABB", "[GJK][raycast]") {
+    float t; glm::vec3 n;
+    glm::mat3 identity(1.0f);
+
+    SECTION("hits, distance is correct") {
+        bool hit = EC_GJK::raycast({ -10, 0, 0 }, { 1, 0, 0 }, 100.0f,
+            boxFn({ 0, 0, 0 }, { 1, 1, 1 }, identity), t, n);
+        REQUIRE(hit);
+        REQUIRE_THAT(t, WithinAbs(9.0f, 0.01f)); // origin -10, face at -1
+    }
+
+    SECTION("ray offset beyond extents misses") {
+        bool miss = EC_GJK::raycast({ -10, 5, 0 }, { 1, 0, 0 }, 100.0f,
+            boxFn({ 0, 0, 0 }, { 1, 1, 1 }, identity), t, n);
+        REQUIRE_FALSE(miss);
+    }
+}
+
+TEST_CASE("GJK raycast: OBB accounts for rotated silhouette", "[GJK][raycast]") {
+    float t; glm::vec3 n;
+    glm::mat3 rot45 = glm::mat3(glm::rotate(glm::mat4(1.0f), glm::radians(45.0f), glm::vec3(0, 1, 0)));
+    bool hit = EC_GJK::raycast({ -10, 0, 0 }, { 1, 0, 0 }, 100.0f,
+        boxFn({ 0, 0, 0 }, { 1, 1, 1 }, rot45), t, n);
+    REQUIRE(hit);
+    // Reach along X for a 45deg-rotated unit-half-extent box is cos45+sin45 ~= 1.41421.
+    REQUIRE_THAT(t, WithinAbs(10.0f - 1.41421f, 0.02f));
+}
+
+TEST_CASE("GJK raycast: capsule body and cap", "[GJK][raycast]") {
+    float t; glm::vec3 n;
+    glm::vec3 a(0, -2, 0), b(0, 2, 0);
+
+    SECTION("through the cylindrical body") {
+        bool hitBody = EC_GJK::raycast({ -10, 0, 0 }, { 1, 0, 0 }, 100.0f, capsuleFn(a, b, 1.0f), t, n);
+        REQUIRE(hitBody);
+        REQUIRE_THAT(t, WithinAbs(9.0f, 0.01f));
+    }
+
+    SECTION("through the rounded top cap only") {
+        // Capsule axis runs along Y, so "above the straight segment" means offsetting
+        // Y past b.y=2, not Z.
+        bool hitCap = EC_GJK::raycast({ -10, 2.5f, 0 }, { 1, 0, 0 }, 100.0f, capsuleFn(a, b, 1.0f), t, n);
+        REQUIRE(hitCap);
+        REQUIRE_THAT(t, WithinAbs(9.134f, 0.05f));
+    }
+}
+
+TEST_CASE("GJK raycast: cylinder flat cap and body", "[GJK][raycast]") {
+    float t; glm::vec3 n;
+    glm::vec3 a(0, -2, 0), b(0, 2, 0);
+
+    SECTION("straight up through the flat bottom cap") {
+        bool hitCap = EC_GJK::raycast({ 0, -10, 0 }, { 0, 1, 0 }, 100.0f, cylinderFn(a, b, 1.0f), t, n);
+        REQUIRE(hitCap);
+        REQUIRE_THAT(t, WithinAbs(8.0f, 0.01f));
+        checkNear(n, { 0, -1, 0 }, 0.01f);
+    }
+
+    SECTION("through the round side") {
+        bool hitBody = EC_GJK::raycast({ -10, 0, 0 }, { 1, 0, 0 }, 100.0f, cylinderFn(a, b, 1.0f), t, n);
+        REQUIRE(hitBody);
+        REQUIRE_THAT(t, WithinAbs(9.0f, 0.01f));
+    }
 }

--- a/tests/EC_PairManager_Tests.cpp
+++ b/tests/EC_PairManager_Tests.cpp
@@ -1,0 +1,53 @@
+// Unit tests for EC_PairManager. Note: all of its state is static/class-level
+// (shared across every instance, and across every test case in this binary),
+// with no reset() - so every TEST_CASE here clears EC_PairManager::getAllPairs()
+// itself on entry to stay isolated from whatever ran before it.
+#include <catch2/catch_test_macros.hpp>
+#include "Engine/Subsystems/CollisionSystems/EC_PairManager.h"
+
+TEST_CASE("EC_PairManager tracks unique pairs regardless of argument order", "[PairManager]") {
+    EC_PairManager::getAllPairs().clear();
+    EC_PairManager mgr;
+
+    mgr.addPair(1, 2);
+    mgr.addPair(2, 1); // same pair, reversed order - must not duplicate
+    mgr.addPair(3, 4);
+
+    REQUIRE(EC_PairManager::getAllPairs().size() == 2);
+}
+
+TEST_CASE("EC_PairManager::update() purges pairs that never went colliding", "[PairManager]") {
+    EC_PairManager::getAllPairs().clear();
+    EC_PairManager mgr;
+
+    mgr.addPair(1, 2);
+    mgr.addPair(3, 4);
+    EC_PairManager::getAllPairs()[0].m_Colliding = true; // pair(1,2) stays
+    // pair(3,4) left non-colliding -> should be dropped by update()
+
+    mgr.update();
+
+    REQUIRE(EC_PairManager::getAllPairs().size() == 1);
+    REQUIRE(EC_PairManager::getAllPairs()[0].body_A == 1);
+    REQUIRE(EC_PairManager::getAllPairs()[0].body_B == 2);
+}
+
+TEST_CASE("EC_PairManager's consuming cursor (hasPairs/getNextPair) drains once per update() cycle", "[PairManager]") {
+    EC_PairManager::getAllPairs().clear();
+    EC_PairManager mgr;
+
+    mgr.addPair(1, 2);
+    mgr.addPair(3, 4);
+    for (auto& p : EC_PairManager::getAllPairs()) p.m_Colliding = true;
+    mgr.update(); // resets the cursor to 0
+
+    REQUIRE(mgr.hasPairs());
+    mgr.getNextPair();
+    REQUIRE(mgr.hasPairs());
+    mgr.getNextPair();
+    REQUIRE_FALSE(mgr.hasPairs());
+
+    REQUIRE_THROWS_AS(mgr.getNextPair(), std::out_of_range);
+
+    EC_PairManager::getAllPairs().clear();
+}

--- a/tests/EC_SpatialGrid_Tests.cpp
+++ b/tests/EC_SpatialGrid_Tests.cpp
@@ -1,0 +1,61 @@
+// Unit tests for EC_SpatialGrid - a self-contained uniform-cell spatial index
+// keyed only on entity id + world AABB. No engine dependency beyond glm and
+// EC_DOD_Types (just a uint32_t alias).
+#include <catch2/catch_test_macros.hpp>
+#include "Spatial/EC_SpatialGrid.h"
+
+TEST_CASE("EC_SpatialGrid queryAABB finds entities inserted into overlapping cells", "[SpatialGrid]") {
+    EC_SpatialGrid grid(10.0f);
+
+    grid.insert(1, AABB{ glm::vec3(-1.0f), glm::vec3(1.0f) });   // cell (0,0,0) region
+    grid.insert(2, AABB{ glm::vec3(50.0f), glm::vec3(52.0f) });  // far away
+
+    auto hits = grid.queryAABB(AABB{ glm::vec3(-2.0f), glm::vec3(2.0f) });
+
+    REQUIRE(hits.size() == 1);
+    REQUIRE(hits[0] == 1);
+}
+
+TEST_CASE("EC_SpatialGrid query region with nothing nearby returns empty", "[SpatialGrid]") {
+    EC_SpatialGrid grid(10.0f);
+    grid.insert(1, AABB{ glm::vec3(-1.0f), glm::vec3(1.0f) });
+
+    auto hits = grid.queryAABB(AABB{ glm::vec3(500.0f), glm::vec3(502.0f) });
+
+    REQUIRE(hits.empty());
+}
+
+TEST_CASE("EC_SpatialGrid an entity spanning multiple cells is found from either cell", "[SpatialGrid]") {
+    EC_SpatialGrid grid(10.0f);
+    // Straddles the boundary between cell (0,0,0) and (1,0,0).
+    grid.insert(7, AABB{ glm::vec3(5.0f, 0.0f, 0.0f), glm::vec3(15.0f, 1.0f, 1.0f) });
+
+    auto hitsLeftCell = grid.queryAABB(AABB{ glm::vec3(0.0f), glm::vec3(1.0f) });
+    auto hitsRightCell = grid.queryAABB(AABB{ glm::vec3(12.0f, 0.0f, 0.0f), glm::vec3(13.0f, 1.0f, 1.0f) });
+
+    REQUIRE(hitsLeftCell.size() == 1);
+    REQUIRE(hitsRightCell.size() == 1);
+    REQUIRE(hitsLeftCell[0] == 7);
+    REQUIRE(hitsRightCell[0] == 7);
+}
+
+TEST_CASE("EC_SpatialGrid clear() empties all previously inserted entities", "[SpatialGrid]") {
+    EC_SpatialGrid grid(10.0f);
+    grid.insert(1, AABB{ glm::vec3(-1.0f), glm::vec3(1.0f) });
+
+    grid.clear();
+    auto hits = grid.queryAABB(AABB{ glm::vec3(-1.0f), glm::vec3(1.0f) });
+
+    REQUIRE(hits.empty());
+}
+
+TEST_CASE("EC_SpatialGrid duplicate inserts of the same entity across overlapping cells still dedupe on query", "[SpatialGrid]") {
+    EC_SpatialGrid grid(10.0f);
+    // AABB spans 4 cells on X/Z at cell size 10; query region overlapping all of them
+    // should report entity 3 exactly once (queryAABB dedupes via unordered_set).
+    grid.insert(3, AABB{ glm::vec3(-5.0f, 0.0f, -5.0f), glm::vec3(5.0f, 1.0f, 5.0f) });
+
+    auto hits = grid.queryAABB(AABB{ glm::vec3(-15.0f), glm::vec3(15.0f) });
+
+    REQUIRE(hits.size() == 1);
+}

--- a/tests/EC_VClip_Tests.cpp
+++ b/tests/EC_VClip_Tests.cpp
@@ -1,0 +1,56 @@
+// Unit tests for EC_VClip::generateContactPoints - given two already-overlapping
+// OBBs plus SAT's normal/depth, verifies it picks a plausible feature pair and
+// produces the right contact-point count (1 for vertex/edge, up to 4 for a
+// genuine face-face rest). Pure glm + shape structs, no engine dependency.
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include "Engine/Subsystems/CollisionSystems/EC_VClip.h"
+
+using Catch::Matchers::WithinAbs;
+
+TEST_CASE("generateContactPoints resolves a flat face-face rest to a 4-point manifold", "[VClip]") {
+    // Box A: a large flat "floor" slab, box B: a unit cube sitting on top of it,
+    // both axis-aligned - classic stable-rest configuration.
+    OBB floorBox{ glm::vec3(0.0f), glm::vec3(10.0f, 0.5f, 10.0f), glm::mat3(1.0f) };
+    OBB cube{ glm::vec3(0.0f), glm::vec3(0.5f), glm::mat3(1.0f) };
+
+    // Floor top face is at y=0.5, cube center at y=0.98 (bottom at 0.48):
+    // slight overlap of 0.02 along Y, matching what SAT would report.
+    glm::vec3 posFloor(0.0f);
+    glm::vec3 posCube(0.0f, 0.98f, 0.0f);
+    glm::vec3 normal(0.0f, 1.0f, 0.0f); // floor -> cube
+    float penetration = 0.02f;
+
+    CollisionManifold manifold;
+    EC_VClip::generateContactPoints(floorBox, posFloor, cube, posCube, normal, penetration, manifold);
+
+    REQUIRE(manifold.contactPoints.size() == 4);
+    // Points land on the incident (cube) face, i.e. the cube's actual bottom
+    // face at y = 0.98 - 0.5 = 0.48, not the reference (floor) face at y = 0.5.
+    for (const auto& p : manifold.contactPoints) {
+        REQUIRE_THAT(p.y, WithinAbs(0.48f, 1e-2f));
+    }
+}
+
+TEST_CASE("generateContactPoints resolves a corner-down tilted box to a single contact point", "[VClip]") {
+    OBB floorBox{ glm::vec3(0.0f), glm::vec3(10.0f, 0.5f, 10.0f), glm::mat3(1.0f) };
+
+    // Classic "cube balanced on a vertex" orientation: Rx(-35.264) * Rz(45),
+    // applied Z-first, sends local corner (-he,-he,-he) to straight down (-Y).
+    glm::mat4 rot = glm::rotate(glm::mat4(1.0f), glm::radians(-35.264f), glm::vec3(1.0f, 0.0f, 0.0f));
+    rot = glm::rotate(rot, glm::radians(45.0f), glm::vec3(0.0f, 0.0f, 1.0f));
+    OBB cube{ glm::vec3(0.0f), glm::vec3(0.5f), glm::mat3(rot) };
+
+    // Lowest corner of the tilted cube is at distance he*sqrt(3) ~= 0.866 from center.
+    // Place it just barely penetrating the floor's top face (y = 0.5).
+    glm::vec3 posFloor(0.0f);
+    glm::vec3 posCube(0.0f, 0.5f + 0.866f - 0.02f, 0.0f);
+    glm::vec3 normal(0.0f, 1.0f, 0.0f);
+    float penetration = 0.02f;
+
+    CollisionManifold manifold;
+    EC_VClip::generateContactPoints(floorBox, posFloor, cube, posCube, normal, penetration, manifold);
+
+    REQUIRE(manifold.contactPoints.size() == 1);
+}


### PR DESCRIPTION
Establishes Tier 1 of the testability review: pure collision/physics-math modules (GJK, ConvexSupport, CollisionChecks, VClip, PairManager, SpatialGrid, Frustum) tested via Catch2, consolidating the old hand-rolled ECX_GJK_Tests target into the single ECX_UnitTests binary.

Adds ECX_BUILD_ENGINE CMake option so CI can configure/build/run just the unit tests without pulling in SDL2/GLEW/assimp/Lua/OpenGL/Stb, and a GitHub Actions workflow that runs them on PRs into develop and on merge.