### PR TITLE
Fix EC_PairManager cross-thread race and lock down its access

### DIFF
--- a/src/Components/EC_DOD_Components.h
+++ b/src/Components/EC_DOD_Components.h
@@ -17,6 +17,16 @@ struct ContactPoint {
     float penetration;
 };
 
+// Published once per physics tick by EC_PhysicsSystem (which already computes
+// per-entity contact points for the sleep/stability check) so debug rendering
+// can draw them without ever touching EC_PairManager - contact points reach
+// the render thread through the same shared_mutex-protected component-array
+// path as every other piece of debug-drawable state (colliders, transforms),
+// rather than reading physics-thread-internal collision-pair data directly.
+struct EC_DOD_DebugContacts {
+    std::vector<glm::vec3> points;
+};
+
 struct EC_DOD_Hierarchy {
     EntityID parent = INVALID_ENTITY;
     std::vector<EntityID> children;

--- a/src/Engine/Subsystems/CollisionSystems/EC_PairManager.h
+++ b/src/Engine/Subsystems/CollisionSystems/EC_PairManager.h
@@ -40,11 +40,40 @@ struct EC_CollisionPair
 	std::vector<EC_ContactImpulseCache> m_ContactCache;
 	EC_CollisionPair() :body_A(0), body_B(0), m_Colliding(false) {}
 };
+// All state below is physics-thread-only working data - collision pairs are
+// produced and consumed entirely within one tick of the collision/physics
+// pipeline (EC_BroadPhase -> EC_NarrowPhase -> EC_CollisionSystem ->
+// EC_PhysicsSystem), all of which run sequentially on the same thread. It is
+// NOT safe to read from any other thread (e.g. the render thread) - there is
+// no synchronization, by design, because nothing outside this pipeline is
+// meant to touch it. Debug rendering gets contact-point data via
+// EC_DOD_DebugContacts instead (published once per tick as component data by
+// EC_PhysicsSystem) rather than reading this class directly - see
+// GL_DebugRenderer::renderContactPoints. The methods below are private and
+// friended to exactly the classes that make up that pipeline, to keep it that
+// way rather than relying on convention.
+class EC_BroadPhase;
+class EC_NarrowPhase;
+class EC_CollisionSystem;
+class EC_PhysicsSystem;
+// Test-only accessor (see tests/EC_PairManager_Tests.cpp) - lets the Catch2
+// suite exercise addPair/update/hasPairs/getNextPair/getAllPairs directly
+// without opening those up to the rest of the engine.
+class EC_PairManagerTestHelper;
+
 class EC_PairManager
 {
 public:
 	EC_PairManager();
 	~EC_PairManager();
+
+private:
+	friend class EC_BroadPhase;
+	friend class EC_NarrowPhase;
+	friend class EC_CollisionSystem;
+	friend class EC_PhysicsSystem;
+	friend class EC_PairManagerTestHelper;
+
 	void addPair(uint32_t id_a, uint32_t id_b);
 	void update();
 	bool hasPairs();
@@ -55,7 +84,7 @@ public:
 	// drained the cursor this tick. Mutable (not just read-only) so physics
 	// can update each pair's m_ContactCache for next tick's warm start.
 	static std::vector<EC_CollisionPair>& getAllPairs();
-private:
+
 	static std::vector<EC_CollisionPair> s_Pairs;
 	static size_t s_CurrentPairIndex;
 };

--- a/src/Engine/Subsystems/EC_PhysicsSystem.cpp
+++ b/src/Engine/Subsystems/EC_PhysicsSystem.cpp
@@ -169,6 +169,26 @@ void EC_PhysicsSystem::update(const float& deltaTimeS, EC_Game& game) {
             pointsB.insert(pointsB.end(), pair.m_CollisionPoints.begin(), pair.m_CollisionPoints.end());
         }
 
+        // Publish this tick's contact points as component data so debug
+        // rendering can draw them via the normal shared_mutex-protected
+        // component-array path, same as it reads colliders/transforms -
+        // instead of reading EC_PairManager (physics-thread-internal) from
+        // the render thread. Only entities actually in bodyContactPoints get
+        // written; anything that had contacts last tick but not this tick
+        // gets explicitly cleared below so stale markers don't linger.
+        std::vector<EntityID> currentContactEntities;
+        currentContactEntities.reserve(bodyContactPoints.size());
+        for (const auto& [entity, points] : bodyContactPoints) {
+            manager.addComponent(entity, EC_DOD_DebugContacts{ points });
+            currentContactEntities.push_back(entity);
+        }
+        for (EntityID entity : m_LastDebugContactEntities) {
+            if (bodyContactPoints.find(entity) == bodyContactPoints.end()) {
+                manager.addComponent(entity, EC_DOD_DebugContacts{});
+            }
+        }
+        m_LastDebugContactEntities = std::move(currentContactEntities);
+
         constexpr int kSolverPasses = 4;
         for (int pass = 0; pass < kSolverPasses; pass++) {
             for (EC_CollisionPair& pair : EC_PairManager::getAllPairs()) {

--- a/src/Engine/Subsystems/EC_PhysicsSystem.h
+++ b/src/Engine/Subsystems/EC_PhysicsSystem.h
@@ -1,5 +1,7 @@
 #pragma once
 #include "EC_System.h"
+#include "Entity/EC_DOD_Types.h"
+#include <vector>
 
 class EC_PairManager;
 
@@ -44,4 +46,8 @@ public:
 private:
     EC_PairManager* m_PairManager = nullptr;
     bool m_LogEnergy = false;
+    // Entities that carried an EC_DOD_DebugContacts component last tick -
+    // diffed against this tick's contact set so entities that stop colliding
+    // get their debug contacts cleared instead of showing stale points.
+    std::vector<EntityID> m_LastDebugContactEntities;
 };

--- a/src/Graphics/GL_DebugRenderer.cpp
+++ b/src/Graphics/GL_DebugRenderer.cpp
@@ -1,7 +1,6 @@
 #include "Graphics/GL_DebugRenderer.h"
 #include "Window/Window.h"
 #include "Logging/ECX_Logging.h"
-#include "Engine/Subsystems/CollisionSystems/EC_PairManager.h"
 #include <glm/gtc/matrix_transform.hpp>
 #include <GL/glew.h>
 #include <cmath>
@@ -246,10 +245,16 @@ void GL_DebugRenderer::renderContactPoints(const glm::mat4& view, const glm::mat
 {
     constexpr float kCrossHalfSize = 0.1f;
 
+    auto& manager = EC_DOD_EntityManager::getInstance();
+    auto entities = manager.getEntitiesWithComponents({
+        std::type_index(typeid(EC_DOD_DebugContacts))
+        });
+
     std::vector<glm::vec3> lines;
-    for (const EC_CollisionPair& pair : EC_PairManager::getAllPairs()) {
-        if (!pair.m_Colliding) continue;
-        for (const glm::vec3& point : pair.m_CollisionPoints) {
+    for (EntityID entity : entities) {
+        if (!manager.isAlive(entity)) continue;
+        const auto& debugContacts = manager.getComponent<EC_DOD_DebugContacts>(entity);
+        for (const glm::vec3& point : debugContacts.points) {
             buildCrossLines(point, kCrossHalfSize, lines);
         }
     }

--- a/src/Graphics/GL_DebugRenderer.h
+++ b/src/Graphics/GL_DebugRenderer.h
@@ -37,11 +37,14 @@ private:
     void renderOBB(const glm::mat4& view, const glm::mat4& projection,
         const EC_DOD_Collider& collider, const EC_DOD_Transform& transform);
     // Draws a small 3-axis cross marker at every contact point of every
-    // currently-colliding pair (EC_PairManager::getAllPairs()) - the same
-    // manifold points EC_PhysicsResolution actually resolves against, so
-    // this is a direct visual check of what the narrow phase is generating
-    // (point count, position, clustering) rather than just the coarse
-    // collider wireframes above. Tied to the same m_Enabled toggle.
+    // currently-colliding entity, read via EC_DOD_DebugContacts (published
+    // once per physics tick by EC_PhysicsSystem) - the same manifold points
+    // EC_PhysicsResolution actually resolves against, so this is a direct
+    // visual check of what the narrow phase is generating (point count,
+    // position, clustering) rather than just the coarse collider wireframes
+    // above. Tied to the same m_Enabled toggle. Deliberately does not read
+    // EC_PairManager directly - that's physics-thread-internal state; this
+    // component is the sanctioned cross-thread hand-off.
     void renderContactPoints(const glm::mat4& view, const glm::mat4& projection);
     void buildCrossLines(const glm::vec3& point, float halfSize, std::vector<glm::vec3>& outLines) const;
 

--- a/tests/EC_PairManager_Tests.cpp
+++ b/tests/EC_PairManager_Tests.cpp
@@ -2,52 +2,72 @@
 // (shared across every instance, and across every test case in this binary),
 // with no reset() - so every TEST_CASE here clears EC_PairManager::getAllPairs()
 // itself on entry to stay isolated from whatever ran before it.
+//
+// EC_PairManager's methods are private, friended only to the physics-thread
+// pipeline classes (EC_BroadPhase/EC_NarrowPhase/EC_CollisionSystem/
+// EC_PhysicsSystem) plus this helper - deliberately, so nothing else in the
+// engine (e.g. render-thread code) can read physics-thread-internal pair
+// state directly. EC_PairManagerTestHelper is declared a friend in
+// EC_PairManager.h purely so this suite can still exercise it directly.
 #include <catch2/catch_test_macros.hpp>
 #include "Engine/Subsystems/CollisionSystems/EC_PairManager.h"
 
+class EC_PairManagerTestHelper {
+public:
+    static void addPair(EC_PairManager& mgr, uint32_t a, uint32_t b) { mgr.addPair(a, b); }
+    static void update(EC_PairManager& mgr) { mgr.update(); }
+    static bool hasPairs(EC_PairManager& mgr) { return mgr.hasPairs(); }
+    static EC_CollisionPair& getNextPair(EC_PairManager& mgr) { return mgr.getNextPair(); }
+    static std::vector<EC_CollisionPair>& getAllPairs() { return EC_PairManager::getAllPairs(); }
+};
+
+namespace {
+    using Helper = EC_PairManagerTestHelper;
+}
+
 TEST_CASE("EC_PairManager tracks unique pairs regardless of argument order", "[PairManager]") {
-    EC_PairManager::getAllPairs().clear();
+    Helper::getAllPairs().clear();
     EC_PairManager mgr;
 
-    mgr.addPair(1, 2);
-    mgr.addPair(2, 1); // same pair, reversed order - must not duplicate
-    mgr.addPair(3, 4);
+    Helper::addPair(mgr, 1, 2);
+    Helper::addPair(mgr, 2, 1); // same pair, reversed order - must not duplicate
+    Helper::addPair(mgr, 3, 4);
 
-    REQUIRE(EC_PairManager::getAllPairs().size() == 2);
+    REQUIRE(Helper::getAllPairs().size() == 2);
 }
 
 TEST_CASE("EC_PairManager::update() purges pairs that never went colliding", "[PairManager]") {
-    EC_PairManager::getAllPairs().clear();
+    Helper::getAllPairs().clear();
     EC_PairManager mgr;
 
-    mgr.addPair(1, 2);
-    mgr.addPair(3, 4);
-    EC_PairManager::getAllPairs()[0].m_Colliding = true; // pair(1,2) stays
+    Helper::addPair(mgr, 1, 2);
+    Helper::addPair(mgr, 3, 4);
+    Helper::getAllPairs()[0].m_Colliding = true; // pair(1,2) stays
     // pair(3,4) left non-colliding -> should be dropped by update()
 
-    mgr.update();
+    Helper::update(mgr);
 
-    REQUIRE(EC_PairManager::getAllPairs().size() == 1);
-    REQUIRE(EC_PairManager::getAllPairs()[0].body_A == 1);
-    REQUIRE(EC_PairManager::getAllPairs()[0].body_B == 2);
+    REQUIRE(Helper::getAllPairs().size() == 1);
+    REQUIRE(Helper::getAllPairs()[0].body_A == 1);
+    REQUIRE(Helper::getAllPairs()[0].body_B == 2);
 }
 
 TEST_CASE("EC_PairManager's consuming cursor (hasPairs/getNextPair) drains once per update() cycle", "[PairManager]") {
-    EC_PairManager::getAllPairs().clear();
+    Helper::getAllPairs().clear();
     EC_PairManager mgr;
 
-    mgr.addPair(1, 2);
-    mgr.addPair(3, 4);
-    for (auto& p : EC_PairManager::getAllPairs()) p.m_Colliding = true;
-    mgr.update(); // resets the cursor to 0
+    Helper::addPair(mgr, 1, 2);
+    Helper::addPair(mgr, 3, 4);
+    for (auto& p : Helper::getAllPairs()) p.m_Colliding = true;
+    Helper::update(mgr); // resets the cursor to 0
 
-    REQUIRE(mgr.hasPairs());
-    mgr.getNextPair();
-    REQUIRE(mgr.hasPairs());
-    mgr.getNextPair();
-    REQUIRE_FALSE(mgr.hasPairs());
+    REQUIRE(Helper::hasPairs(mgr));
+    Helper::getNextPair(mgr);
+    REQUIRE(Helper::hasPairs(mgr));
+    Helper::getNextPair(mgr);
+    REQUIRE_FALSE(Helper::hasPairs(mgr));
 
-    REQUIRE_THROWS_AS(mgr.getNextPair(), std::out_of_range);
+    REQUIRE_THROWS_AS(Helper::getNextPair(mgr), std::out_of_range);
 
-    EC_PairManager::getAllPairs().clear();
+    Helper::getAllPairs().clear();
 }


### PR DESCRIPTION
GL_DebugRenderer was reading EC_PairManager::getAllPairs() from the render thread every frame while the physics thread concurrently mutated the same static vector via EC_NarrowPhase/EC_PhysicsSystem - an unsynchronized data race (iterator invalidation, torn reads).

Rather than adding a lock for the renderer's benefit, the debug renderer no longer touches EC_PairManager at all. EC_PhysicsSystem now publishes each tick's per-entity contact points (already computed for the sleep/stability check) onto a new EC_DOD_DebugContacts component, via the same shared_mutex-protected component-array path the renderer already uses for colliders/transforms. EC_PairManager's methods are now private, friended only to the physics-thread pipeline classes (EC_BroadPhase, EC_NarrowPhase, EC_CollisionSystem, EC_PhysicsSystem) plus a test-only helper, so nothing outside that pipeline can read its state again by accident.

Verified ECX and ECX_UnitTests both build clean (88/88 assertions), and manually confirmed F1 debug-contact visualization still renders correctly in a live scene.