### PR TITLE
Fix EC_DOD_Light uninitialized fields and clean up compiler warnings

### DIFF
--- a/src/Components/EC_DOD_Components.h
+++ b/src/Components/EC_DOD_Components.h
@@ -178,20 +178,24 @@ struct EC_DOD_Light {
         Point,
         Spot
     };
-    Type type;
-    glm::vec3 position;
-    glm::vec3 direction;
-    glm::vec3 colour;
-    float intensity;
+    Type type = Type::Point;
+    glm::vec3 position{ 0.0f };
+    glm::vec3 direction{ 0.0f, -1.0f, 0.0f };
+    glm::vec3 colour{ 1.0f };
+    float intensity = 1.0f;
     // Distance beyond which this light's contribution falls below a perceptible
     // threshold (1/256, the smallest step an 8-bit colour channel can represent).
     // Computed once at load time (see EC_DOD_EntityFactory::parseLight) from
     // intensity/attenuation - not meaningful for Directional lights (left at 0).
-    float cutoffRadius;
-    float cutoffAngle;
-    glm::vec3 attenuation;
-    bool castsShadow;
-    bool dynamic;
+    float cutoffRadius = 0.0f;
+    float cutoffAngle = glm::radians(45.0f);
+    // Constant-only by default (no linear/quadratic falloff) - this is exactly
+    // the degenerate case computeLightCutoffRadius already falls back to a
+    // fixed radius for, so an XML entry that omits <Attenuation> gets that
+    // designed fallback instead of reading garbage.
+    glm::vec3 attenuation{ 1.0f, 0.0f, 0.0f };
+    bool castsShadow = false;
+    bool dynamic = false;
 };
 
 struct EC_DOD_EntityInfo {

--- a/src/Engine/Subsystems/EC_LuaScriptingSystem.h
+++ b/src/Engine/Subsystems/EC_LuaScriptingSystem.h
@@ -393,7 +393,13 @@ private:
             .addFunction("showDebugCone", &ScriptAPI::GameAPI::showDebugCone)
             .endClass();
 
-        luabridge::push(m_luaState, m_game);
+        auto pushResult = luabridge::push(m_luaState, m_game);
+        if (!pushResult) {
+            LOGGING::ECX_Logger::GetInstance()->LogMessage(
+                "Failed to push 'game' global into Lua state: " + pushResult.message(),
+                LOGGING::LogLevel::SEVERE
+            );
+        }
         lua_setglobal(m_luaState, "game");
     }
 };

--- a/src/Entity/EC_DOD_EntityFactory.cpp
+++ b/src/Entity/EC_DOD_EntityFactory.cpp
@@ -562,7 +562,7 @@ void EC_DOD_EntityFactory::parseGraphics(TiXmlElement* elem, EntityID entity) {
         }
         else if (strcmp(child->Value(), "Colour") == 0 || strcmp(child->Value(), "Color") == 0) {
             std::string color = child->GetText();
-            sscanf(color.c_str(), "%f,%f,%f,%f",
+            TIXML_SSCANF(color.c_str(), "%f,%f,%f,%f",
                 &gfx.colour.r, &gfx.colour.g, &gfx.colour.b, &gfx.colour.a);
         }
         else if (strcmp(child->Value(), "CastsShadow") == 0 && child->GetText()) {
@@ -805,7 +805,7 @@ void EC_DOD_EntityFactory::parseCollider(TiXmlElement* elem, EntityID entity) {
 
     auto extentsElem = elem->FirstChildElement("Extents");
     if (extentsElem && extentsElem->GetText())
-        sscanf(extentsElem->GetText(), "%f,%f,%f",
+        TIXML_SSCANF(extentsElem->GetText(), "%f,%f,%f",
             &collider.extents.x, &collider.extents.y, &collider.extents.z);
 
     auto heightElem = elem->FirstChildElement("Height");
@@ -814,7 +814,7 @@ void EC_DOD_EntityFactory::parseCollider(TiXmlElement* elem, EntityID entity) {
 
     auto centerElem = elem->FirstChildElement("Center");
     if (centerElem && centerElem->GetText())
-        sscanf(centerElem->GetText(), "%f,%f,%f",
+        TIXML_SSCANF(centerElem->GetText(), "%f,%f,%f",
             &collider.center.x, &collider.center.y, &collider.center.z);
 
     auto layerElem = elem->FirstChildElement("Layer");

--- a/src/Graphics/CubemapManager.cpp
+++ b/src/Graphics/CubemapManager.cpp
@@ -138,6 +138,12 @@ unsigned int CubemapManager::convertEquirectToCubemap(float* pixels, int width, 
     glRenderbufferStorage(GL_RENDERBUFFER, GL_DEPTH_COMPONENT24, 512, 512);
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rbo);
     GLenum fboStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+    if (fboStatus != GL_FRAMEBUFFER_COMPLETE) {
+        LOGGING::ECX_Logger::GetInstance()->LogMessage(
+            "CubemapManager: equirect-to-cubemap FBO incomplete, status=" + std::to_string(fboStatus),
+            LOGGING::LogLevel::CRITICAL
+        );
+    }
     glm::mat4 captureProjection = glm::perspective(glm::radians(90.0f), 1.0f, 0.1f, 10.0f);
     glm::mat4 captureViews[] = {
         glm::lookAt(glm::vec3(0), glm::vec3(1, 0, 0), glm::vec3(0,-1, 0)),

--- a/src/Graphics/TextureManager.cpp
+++ b/src/Graphics/TextureManager.cpp
@@ -36,10 +36,8 @@ int TextureManager::loadTexture(const std::string & filename)
 		LOGGING::ECX_Logger::GetInstance()->LogMessage("image load fail: " + filename, LOGGING::LogLevel::SEVERE);
 		return -1;
 	}
-	int BPP = surface->format->BytesPerPixel;
-
 	//SDL_image loads pixels with incorrect origin for OpenGL, so we must flip the image, around the horizontal axis
-	//flipYpixels(BPP, (char*)surface->pixels, surface->w, surface->h); //pitch is the true image width, including padding
+	//flipYpixels(surface->format->BytesPerPixel, (char*)surface->pixels, surface->w, surface->h); //pitch is the true image width, including padding
 	m_img_data.emplace(filename, surface);
 
 	return 0;

--- a/src/Logging/ECX_Logging.cpp
+++ b/src/Logging/ECX_Logging.cpp
@@ -62,7 +62,8 @@ namespace LOGGING
 
         std::stringstream ss;
         auto t = std::time(nullptr);
-        auto tm = *std::localtime(&t);
+        std::tm tm{};
+        localtime_s(&tm, &t);
 
         ss << std::put_time(&tm, "%d-%m-%Y %H:%M:%S") << ": ";
 
@@ -140,7 +141,8 @@ namespace LOGGING
 
         // ===== Session Start =====
         auto startTime = std::time(nullptr);
-        auto startTm = *std::localtime(&startTime);
+        std::tm startTm{};
+        localtime_s(&startTm, &startTime);
 
         out << "<hr>\n";
         out << "<h2>Log Session Start: "
@@ -193,7 +195,8 @@ namespace LOGGING
 
         // ===== Session End =====
         auto endTime = std::time(nullptr);
-        auto endTm = *std::localtime(&endTime);
+        std::tm endTm{};
+        localtime_s(&endTm, &endTime);
 
         out << "<h3>Log Session End: "
             << std::put_time(&endTm, "%d-%m-%Y %H:%M:%S")

--- a/src/SceneManager/EC_SceneManager.cpp
+++ b/src/SceneManager/EC_SceneManager.cpp
@@ -143,11 +143,6 @@ void EC_SceneManager::update(float deltaTimeS, EC_Game& game)
         }
     }
 
-    if (m_Loader->isLoading())
-    {
-        float progress = m_Loader->getProgress();
-    }
-
     m_Renderer->renderScene(m_Scenes[m_ActiveScene]);
 }
 

--- a/src/TaskManager/EC_ThreadManager.cpp
+++ b/src/TaskManager/EC_ThreadManager.cpp
@@ -29,7 +29,7 @@ std::deque<std::shared_ptr<EC_Task>> EC_ThreadManager::s_Tasks;
 std::mutex EC_ThreadManager::s_Lock;
 std::condition_variable EC_ThreadManager::s_Flag;
 bool EC_ThreadManager::s_running;
-int EC_ThreadManager::s_activeThreads;
+size_t EC_ThreadManager::s_activeThreads;
 
 EC_ThreadManager::EC_ThreadManager()
 {

--- a/src/TaskManager/EC_ThreadManager.h
+++ b/src/TaskManager/EC_ThreadManager.h
@@ -26,5 +26,5 @@ private:
 	static std::mutex s_Lock;
 	static std::condition_variable s_Flag;
 	static bool s_running;
-	static int s_activeThreads;
+	static size_t s_activeThreads;
 };


### PR DESCRIPTION
EC_DOD_Light had no default member initializers, so a scene's <Light> entry omitting a field (e.g. <Intensity> or <Attenuation> on a Point/Spot light) left that field as genuine garbage feeding directly into computeLightCutoffRadius - not just an MSVC C4701 warning, a real correctness bug. Every field now has a sensible default; the attenuation default in particular routes through the fallback radius computeLightCutoffRadius already has for the degenerate case.

Also addresses the rest of the project's /W4 warning list that was worth acting on rather than just counting:
- sscanf -> TIXML_SSCANF (tinyxml's own portable macro) in EC_DOD_EntityFactory.cpp, removing the deprecated-CRT-call warnings.
- localtime -> localtime_s in ECX_Logging.cpp, removing both the warning and the shared-static-buffer thread-safety hazard.
- EC_ThreadManager::s_activeThreads changed int -> size_t to match what it's actually assigned from/used for, fixing a narrowing warning.
- A discarded [[nodiscard]] luabridge::push result in EC_LuaScriptingSystem.h (visible on every normal build, not just /W4) is now checked and logged on failure.
- Three initialized-but-unused locals: CubemapManager.cpp now checks and logs FBO completeness (matching ShadowAtlas.cpp/GBuffer.cpp's existing pattern) instead of discarding the status; TextureManager.cpp and EC_SceneManager.cpp had genuinely dead computations removed.