### PR TITLE
Fix directional/spot shadow detachment via camera-fit frustum and rea…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,7 @@ project(ECX LANGUAGES CXX)
 
 set(SOURCE_DIR ${PROJECT_SOURCE_DIR}/src)
 
-# Off in CI (unit-test workflow): skips the main ECX target and its heavy
-# SDL2/GLEW/assimp/Lua/OpenGL/Stb dependencies entirely, so `cmake --build
-# --target ECX_UnitTests` only needs glm + Catch2 to configure.
+# Off in CI: lets ECX_UnitTests configure with only glm + Catch2.
 option(ECX_BUILD_ENGINE "Build the main ECX game target (requires SDL2/GLEW/assimp/Lua/OpenGL/Stb)" ON)
 
 set(CMAKE_GENERATOR_PLATFORM x64)
@@ -24,13 +22,7 @@ find_package(Catch2 CONFIG REQUIRED)
 
 if(ECX_BUILD_ENGINE)
 
-# Explicit sources, not a glob: each src/ subdirectory owns a CMakeLists.txt
-# calling target_sources(ECX PRIVATE ...) with its own files (relative paths
-# resolve against that subdirectory - CMP0076, default NEW as of the 3.13
-# minimum above), so it's visible from the directory listing alone which
-# files belong to the build, and a stray file added to a directory without
-# updating its CMakeLists.txt is silently excluded rather than silently
-# swept in.
+# Explicit sources, not a glob - each src/ subdirectory owns a CMakeLists.txt.
 add_executable(ECX
     src/Eclipsis.cpp
     src/Game.cpp
@@ -164,12 +156,7 @@ add_custom_command(
 
 endif() # ECX_BUILD_ENGINE
 
-# Catch2-based unit tests for the pure-logic collision/spatial modules (Tier 1 of
-# the testability review): GJK/ConvexSupport, CollisionChecks, VClip, PairManager,
-# SpatialGrid, Frustum. Deliberately isolated from the main ECX target: only
-# depends on glm + Catch2, not SDL/GLEW/assimp/Lua/the ECS, so it builds fast and
-# can run headless without a graphics context.
-
+# Pure-logic collision/spatial unit tests - only depends on glm + Catch2, not the engine.
 add_executable(ECX_UnitTests
     tests/EC_GJK_Tests.cpp
     tests/EC_CollisionChecks_Tests.cpp

--- a/data/assets/shaders/DirLightShadowPBR.frag
+++ b/data/assets/shaders/DirLightShadowPBR.frag
@@ -38,6 +38,10 @@ uniform mat4 ShadowTransform;
 uniform DirLightData dirLight;
 out vec4 colour;
 uniform vec3 WSCamPos;
+// World-space depth span (far-near) of the ortho box this frame's ShadowTransform was built
+// from - needed to convert a world-space bias into the right NDC offset, since the box's
+// depth range varies with the camera-fit frustum instead of being a fixed constant.
+uniform float ShadowDepthRange;
 
 in xferBlock
 {
@@ -128,17 +132,45 @@ vec3 computeLight(
 	// reflectance equation
 	// add to outgoing radiance Lo
 	vec3 Lo = (kD * albedo / PI + specular) * radiance * NdotL;  // note that we already multiplied the BRDF by the Fresnel (kS) so we won't multiply by kS again
-	vec3 color	= (albedo * 0.2)  + Lo;  
 	return Lo;
 }
 
-float computeOcclusion(vec4 shadowCoords)
+float computeOcclusion(vec4 shadowCoords, vec3 normal, vec3 lightDir)
 {
+	// shadowMap is a sampler2DShadow (GL_TEXTURE_COMPARE_MODE = GL_COMPARE_R_TO_TEXTURE) -
+	// this texture() call already performs the hardware depth comparison and hardware PCF.
+	// Bias belongs here, on the READ side, biasing the RECEIVING fragment's own depth before
+	// the comparison - not on the write side (glPolygonOffset / vertex-normal-offset during
+	// the depth-map render), which shifts what gets recorded as the occluder's depth instead.
+	// The two are not interchangeable: a write-side offset and a read-side one produce
+	// genuinely different results, not a shared "more/less bias" knob - see
+	// learnopengl.com/Advanced-Lighting/Shadows/Shadow-Mapping. Slope-scaled against the
+	// receiving surface (steeper angle to the light needs more bias) matching that reference,
+	// converted from a fixed world-space amount into NDC via the box's actual depth range,
+	// since that range varies with the camera-fit frustum instead of being a fixed constant.
 	vec3 coord 			= vec3(shadowCoords.xyz/shadowCoords.w);
-	float depth 		= texture( shadowMap, vec3(coord.xy,coord.z));
-	if ( depth < coord.z - 0.001) // bias = 0.001
-		return 0.2;
-	return 1.0;
+	// ShadowTransform already includes the atlas's bias matrix, which maps NDC [-1,1] to
+	// texture space [0,1] (a further 0.5x on top of ortho's own [-1,1]-over-depthRange
+	// mapping) - so the correct world->this-space conversion is 1.0/depthRange, not
+	// 2.0/depthRange (an earlier version of this file used 2.0 here, effectively doubling
+	// the intended bias - the mix() values below are already calibrated against the
+	// corrected 1.0 factor).
+	float worldBias 	= mix(0.1, 0.001, max(dot(normal, lightDir), 0.0));
+	float ndcBias 		= worldBias * (1.0 / max(ShadowDepthRange, 1.0));
+
+	// Software PCF: average a 3x3 neighbourhood of shadow-map texels instead of relying on
+	// just the single hardware-filtered (2x2 bilinear) sample - smooths out the kind of
+	// hairline crack/split that shows up right at a caster's silhouette edge when that edge
+	// happens to fall near a texel boundary. See learnopengl.com/Advanced-Lighting/Shadows/
+	// Shadow-Mapping's PCF section.
+	vec2 texelSize = 1.0 / vec2(textureSize(shadowMap, 0));
+	float lit = 0.0;
+	for (int x = -1; x <= 1; x++)
+		for (int y = -1; y <= 1; y++)
+			lit += texture(shadowMap, vec3(coord.xy + vec2(x, y) * texelSize, coord.z - ndcBias));
+	lit /= 9.0;
+
+	return mix(0.2, 1.0, lit);
 }
 
 void main()
@@ -149,7 +181,7 @@ void main()
 	vec3 dcolour 		= pow(texture(AlbedoMap, indata.VSTexCoord).rgb,vec3(2.2));
 	vec3 pbr 			= texture(PBRMap, indata.VSTexCoord).rgb;
 	vec4 shadowCoord 	= ShadowTransform * pcolour;
-	float visibility 	= computeOcclusion( shadowCoord );
+	float visibility 	= computeOcclusion( shadowCoord, ncolour.rgb, -dirLight.direction.xyz );
 	vec3 vToEye 		= WSCamPos - pcolour.xyz;
 	vToEye 				= normalize(vToEye);
 	vec3 outColour 		= vec3(0.0,0.0,0.0);

--- a/data/assets/shaders/SpotlightShadowPBR.frag
+++ b/data/assets/shaders/SpotlightShadowPBR.frag
@@ -127,16 +127,16 @@ vec3 computeLight(
 	vec3 Lo = vec3(0.0);
 	// add to outgoing radiance Lo
 	Lo += (kD * albedo / PI + specular) * radiance * NdotL;  // note that we already multiplied the BRDF by the Fresnel (kS) so we won't multiply by kS again
-	vec3 color	= (albedo * 0.2)  + Lo;  
 	return Lo;
 }
 float computeOcclusion(vec4 shadowCoords)
 {
+	// shadowMap is a sampler2DShadow (GL_TEXTURE_COMPARE_MODE = GL_COMPARE_R_TO_TEXTURE) -
+	// this texture() call already performs the hardware depth comparison and hardware PCF,
+	// returning the comparison result (0..1), not a raw depth to compare again.
 	vec3 coord 			= vec3(shadowCoords.xyz/shadowCoords.w);
-	float depth 		= texture( shadowMap, vec3(coord.xy,coord.z));
-	if ( depth < coord.z - 0.001)
-		return 0.2;
-	return 1.0;
+	float lit 			= texture( shadowMap, vec3(coord.xy,coord.z));
+	return mix(0.2, 1.0, lit);
 }
 
 void main()
@@ -147,12 +147,12 @@ void main()
 	vec4 albedo 		= texture(AlbedoMap, indata.VSTexCoord).rgba;
 	vec3 pbr 			= texture(PBRMap, indata.VSTexCoord).rgb;
 	vec4 shadowCoords 	= ShadowTransform * pcolour;
+	vec3 ltf 			= spotLight.position.xyz - pcolour.rgb;
 	float visibility 	= computeOcclusion( shadowCoords );
 	vec3 vToEye 		= WSCamPos - pcolour.xyz;
 	vToEye 				= normalize(vToEye);
 	vec3 outColour 		= vec3(0.0,0.0,0.0);
 
-	vec3 ltf 			= spotLight.position.xyz - pcolour.rgb;
 	float cos_cur_angle = dot(normalize(-ltf),spotLight.direction.xyz);
 	if (cos_cur_angle > cos(spotLight.cutoffAngle))
 	{

--- a/data/assets/shaders/shadow.vert
+++ b/data/assets/shaders/shadow.vert
@@ -2,9 +2,15 @@
 // Some drivers require the following
 precision highp float;
 layout (location = 0)in vec3 MSVertex;
-layout (location = 0) uniform mat4 ModelTransform;
-layout (location = 1) uniform mat4 ViewTransform;
-layout (location = 2) uniform mat4 ProjTransform;
+// Locations 10-12, not 0-2: this vertex shader is also linked against the "Exempt" lighting
+// shaders (ShadowExempt*LightPass.frag), whose G-buffer samplers already claim locations
+// 0-3 - explicit locations must be unique across the whole linked program, not just within
+// one stage, so sharing 0-2 with those silently failed to link (see Shader::loadShader's
+// GL_LINK_STATUS check). Uniforms are still set by name from C++, so the actual numbers
+// here don't matter as long as they're free.
+layout (location = 10) uniform mat4 ModelTransform;
+layout (location = 11) uniform mat4 ViewTransform;
+layout (location = 12) uniform mat4 ProjTransform;
 void main()
 {
 	gl_Position = ProjTransform * ViewTransform * ModelTransform * vec4(MSVertex,1.0);

--- a/data/scripts/LUA/DebugSceneKeyDown.lua
+++ b/data/scripts/LUA/DebugSceneKeyDown.lua
@@ -1,0 +1,56 @@
+-- All OnKeyDown handling for ShadowDebug.xml in one script, bound once to the camera
+-- entity. NOT split across multiple scripts each defining their own onKeyDown(): every
+-- Lua script in this project shares a single global interpreter state
+-- (EC_LuaScriptSystem::m_luaState) and is executed exactly once via luaL_dofile, cached by
+-- filename - two scripts both defining a global function named onKeyDown silently clobber
+-- each other (whichever loads second wins, permanently), not layer/coexist. That's a real
+-- gap in the scripting system worth fixing properly later; consolidating here avoids it for
+-- now without touching the project's existing shared OnKeyDown.lua.
+
+mouseCaptured = true
+gamePaused = true
+
+lightCycleNames = { "debug_sun", "debug_spot", "debug_point" }
+lightCycleIndex = 0 -- 0 = nothing activated yet; first L press selects index 1
+
+local function applyLightCycle()
+    for i, name in ipairs(lightCycleNames) do
+        -- activate()/deactivate() are no-ops on an invalid/dead entity ID, so no need to
+        -- check the lookup succeeded before calling them.
+        local light = game:getEntityByName(name)
+        if i == lightCycleIndex then
+            light:activate()
+        else
+            light:deactivate()
+        end
+    end
+end
+
+function onKeyDown(entity, event)
+    local key = event:getKey()
+
+    if key == "Escape" then
+        print("Escape key pressed, shutting down the game.")
+        game:shutdown()
+    end
+    if key == "F3" then
+        debugOverlayVisible = not debugOverlayVisible
+    end
+    if key == "F4" then
+        mouseCaptured = not mouseCaptured
+        game:setMouseCaptured(mouseCaptured)
+    end
+    if key == "P" then
+        gamePaused = not gamePaused
+        if gamePaused then
+            game:pauseGame()
+        else
+            game:resumeGame()
+        end
+    end
+    if key == "L" then
+        lightCycleIndex = (lightCycleIndex % #lightCycleNames) + 1
+        applyLightCycle()
+        print("CycleLights: active light " .. lightCycleNames[lightCycleIndex])
+    end
+end

--- a/data/scripts/XML/GraphicsSetting.xml
+++ b/data/scripts/XML/GraphicsSetting.xml
@@ -3,6 +3,6 @@
 	<Exposure>0.75</Exposure>
 	<EmissiveIntensity>2.0</EmissiveIntensity>
 	<BloomMipLevels>6</BloomMipLevels>
-	<ShadowAtlas size="4096" tileSize="1024"/>
+	<ShadowAtlas size="4096" tileSize="2048"/>
 	<PointShadowPool size="6" faceSize="1024"/>
 </GraphicsSettings>

--- a/data/scripts/XML/LargeYard.xml
+++ b/data/scripts/XML/LargeYard.xml
@@ -62,7 +62,7 @@
 			<Colour>1.0,1.0,1.0,1.0</Colour>
 			<Intensity>0.6</Intensity>
 			<CastsShadow>true</CastsShadow>
-			<Dynamic>false</Dynamic>
+			<Dynamic>true</Dynamic>
 		</Light>
 	</Entity>
 
@@ -76,7 +76,7 @@
 			<Cutoff>45.0</Cutoff>
 			<Attenuation>1.0,0.05,0.005</Attenuation>
 			<CastsShadow>true</CastsShadow>
-			<Dynamic>false</Dynamic>
+			<Dynamic>true</Dynamic>
 		</Light>
 	</Entity>
 

--- a/data/scripts/XML/Scenes.XML
+++ b/data/scripts/XML/Scenes.XML
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <Scenes>
-	<Scene alias="physics_demo" precache="true" unloadondeactivate="false">data/scripts/XML/PhysicsDemo.xml</Scene>
+	<Scene alias="shadowdebug" precache="true" unloadondeactivate="false">data/scripts/XML/ShadowDebug.xml</Scene>
 	<Scene alias="yard" precache="false" unloadondeactivate="false">data/scripts/XML/LargeYard.xml</Scene>
+	<Scene alias="physics_demo" precache="false" unloadondeactivate="false">data/scripts/XML/PhysicsDemo.xml</Scene>
 	<Scene alias="main" precache="false" unloadondeactivate="false">data/scripts/XML/Scene1.xml</Scene>
 	<Scene alias="streamed" precache="false" unloadondeactivate="true">data/scripts/XML/StreamedZone.xml</Scene>
 </Scenes>

--- a/data/scripts/XML/ShadowDebug.xml
+++ b/data/scripts/XML/ShadowDebug.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0"?>
+<Scene>
+	<Manifest>
+		<HDR alias="nightsky">data/assets/Images/Skybox/qwantani_moon_noon_puresky_4k.hdr</HDR>
+		<LuaScript alias="keydown">data/scripts/LUA/OnKeyDown.lua</LuaScript>
+		<LuaScript alias="keyup">data/scripts/LUA/OnKeyUp.lua</LuaScript>
+		<LuaScript alias="keyheld">data/scripts/LUA/OnKeyHeld.lua</LuaScript>
+		<LuaScript alias="mousemove">data/scripts/LUA/onMouseMove.lua</LuaScript>
+		<PBRMaterial alias="crate_material">
+			<Albedo>data/assets/Images/Crate/Crate_D.png</Albedo>
+			<Normal>data/assets/Images/Crate/crate_normal.png</Normal>
+			<Metallic>data/assets/Images/Crate/crate_metallic.png</Metallic>
+			<Height>data/assets/Images/Crate/crate_height.png</Height>
+			<Emissive>data/assets/Images/Crate/Crate_E.png</Emissive>
+			<AO>data/assets/Images/Crate/crate_ao.png</AO>
+			<Smoothness>data/assets/Images/Crate/crate_smoothness.png</Smoothness>
+			<ParallaxScale>0.05</ParallaxScale>
+			<ParallaxBias>0.001</ParallaxBias>
+		</PBRMaterial>
+		<Model alias="cratemesh">data/assets/models/crate.obj</Model>
+		<Model alias="plane">data/assets/models/plane.obj</Model>
+		<Shader alias="pbrshader" vertex="data/assets/shaders/basic.vert" fragment="data/assets/shaders/PBR.frag"></Shader>
+	</Manifest>
+
+	<!-- Minimal repro scene for the directional-shadow camera-fit bug: exactly one
+	     caster, one floor, one directional light. LargeYard/PhysicsDemo have too many
+	     overlapping casters to tell a genuine frustum-fit bug apart from ordinary
+	     multi-shadow interaction. -->
+
+	<Entity uid="200" name="debug_skybox">
+		<Skybox>
+			<HDR alias="nightsky"/>
+		</Skybox>
+	</Entity>
+
+	<Entity uid="201" name="debug_camera">
+		<Camera>
+			<FOV>60.0</FOV>
+			<DrawDistance>100.0</DrawDistance>
+		</Camera>
+		<Spatial>
+			<Position>0.0,5.0,-15.0</Position>
+			<Orientation>0.0,0.0,0.0</Orientation>
+		</Spatial>
+		<ScriptComponent>
+			<OnKeyDown filename="data/scripts/LUA/DebugSceneKeyDown.lua"/>
+			<OnKeyUp alias="keyup"/>
+			<OnKeyHeld alias="keyheld"/>
+			<OnMouseMove alias="mousemove"/>
+		</ScriptComponent>
+	</Entity>
+
+	<Entity uid="202" name="debug_sun">
+		<Light>
+			<Type>Directional</Type>
+			<Direction>0.3,-1.0,0.2,0.0</Direction>
+			<Colour>1.0,1.0,1.0,1.0</Colour>
+			<Intensity>1.0</Intensity>
+			<CastsShadow>true</CastsShadow>
+			<Dynamic>true</Dynamic>
+		</Light>
+	</Entity>
+
+	<Entity uid="203" name="debug_spot">
+		<Light>
+			<Type>Spotlight</Type>
+			<Position>1.5,8.0,0.0</Position>
+			<Direction>0.0,-1.0,0.0,0.0</Direction>
+			<Colour>1.0,1.0,1.0,1.0</Colour>
+			<Intensity>3.0</Intensity>
+			<Cutoff>40.0</Cutoff>
+			<Attenuation>1.0,0.05,0.005</Attenuation>
+			<CastsShadow>true</CastsShadow>
+			<Dynamic>true</Dynamic>
+		</Light>
+	</Entity>
+
+	<Entity uid="204" name="debug_point">
+		<Light>
+			<Type>Point</Type>
+			<Position>1.5,3.0,-3.0</Position>
+			<Colour>1.0,0.8,0.6,1.0</Colour>
+			<Intensity>3.0</Intensity>
+			<Attenuation>1.0,0.05,0.005</Attenuation>
+			<CastsShadow>true</CastsShadow>
+			<Dynamic>true</Dynamic>
+		</Light>
+	</Entity>
+
+	<Entity name="debug_cube">
+		<Spatial>
+			<Position>0.0,1.5,0.0</Position>
+			<Orientation>0.0,0.0,0.0</Orientation>
+		</Spatial>
+		<Transform>
+			<Scale>1.0,1.0,1.0</Scale>
+		</Transform>
+		<Gfx>
+			<PBRMaterial alias="crate_material"/>
+			<Model alias="cratemesh"/>
+			<Shader alias="pbrshader"/>
+		</Gfx>
+	</Entity>
+
+	<Entity name="debug_cube_grounded">
+		<Spatial>
+			<Position>3.0,1.0,0.0</Position>
+			<Orientation>0.0,0.0,0.0</Orientation>
+		</Spatial>
+		<Transform>
+			<Scale>1.0,1.0,1.0</Scale>
+		</Transform>
+		<Gfx>
+			<PBRMaterial alias="crate_material"/>
+			<Model alias="cratemesh"/>
+			<Shader alias="pbrshader"/>
+		</Gfx>
+	</Entity>
+
+	<Entity name="debug_floor">
+		<Spatial>
+			<Position>0.0,0.0,0.0</Position>
+		</Spatial>
+		<Transform>
+			<Scale>5.0,5.0,5.0</Scale>
+		</Transform>
+		<Gfx>
+			<Colour>1.0,1.0,1.0,1.0</Colour>
+			<Model alias="plane"/>
+			<Shader alias="pbrshader"/>
+		</Gfx>
+	</Entity>
+</Scene>

--- a/src/Graphics/Renderers/GL_Deferred_Renderer.cpp
+++ b/src/Graphics/Renderers/GL_Deferred_Renderer.cpp
@@ -12,11 +12,14 @@
 #include "Messaging/ECXMessenger.h"
 #include "Messaging/ECXRequest.h"
 #include "Messaging/ECXResponse.h"
+#include "Spatial/RayQueryHit.h"
 #include "SceneManager/EC_GameScene.h"
 #include "UI/EC_UI_Components.h"
 #include "Graphics/Renderers/DebugVisualization.h"
 #include <algorithm>
 #include <typeindex>
+#include <array>
+#include <limits>
 
 namespace {
     // Not tunable: a cubemap's 6 faces exactly tile a full sphere only when
@@ -24,6 +27,90 @@ namespace {
     // shadow cubemap requires this FOV geometrically, unlike the spot/point
     // near/far planes below which are genuine render-quality tradeoffs.
     constexpr float kCubemapFaceFovDegrees = 90.0f;
+
+    // The 8 corners of the camera's view frustum in world space, clamped to [nearPlane,
+    // farPlane] rather than the camera's own draw distance - used to fit the directional
+    // shadow's ortho box to what the camera can actually see (see shadowDirPass).
+    std::array<glm::vec3, 8> computeCameraFrustumCorners(
+        const glm::mat4& camView, float fovDeg, float aspect, float nearPlane, float farPlane)
+    {
+        glm::mat4 proj = glm::perspective(glm::radians(fovDeg), aspect, nearPlane, farPlane);
+        glm::mat4 invViewProj = glm::inverse(proj * camView);
+        std::array<glm::vec3, 8> corners;
+        int idx = 0;
+        for (int x = 0; x < 2; x++)
+            for (int y = 0; y < 2; y++)
+                for (int z = 0; z < 2; z++)
+                {
+                    glm::vec4 pt = invViewProj * glm::vec4(2.0f * x - 1.0f, 2.0f * y - 1.0f, 2.0f * z - 1.0f, 1.0f);
+                    corners[idx++] = glm::vec3(pt) / pt.w;
+                }
+        return corners;
+    }
+
+    // Small, fixed padding on the X/Y (texel-density-determining) axes, just enough to
+    // cover a caster whose center sits right at the frustum edge but whose geometry pokes
+    // a little past it. Deliberately NOT m_ShadowQueryRadius-sized - padding X/Y directly
+    // widens the box and divides the same tile resolution across more world space, so a
+    // large XY margin quietly destroys shadow resolution instead of catching more casters.
+    constexpr float kShadowBoxXYMargin = 3.0f;
+    // Same reasoning as the XY margin above, applied to depth: catches casters just beyond
+    // the visible frustum's near/far without blowing the box's Z range out to hundreds of
+    // units. A too-large Z margin doesn't cost texel density, but it does wreck the shadow
+    // map's DEPTH PRECISION (the whole range gets crammed into the same fixed-point depth
+    // buffer), which shows up as false self-shadowing/acne once the existing polygon-offset
+    // bias (tuned for the old ~30-unit range) is no longer big enough relative to how
+    // coarsely a much larger range quantizes.
+    constexpr float kShadowBoxZMargin = 20.0f;
+
+    // Bounding-sphere fit, not a raw AABB of the transformed corners. An AABB's own size
+    // depends on the corners' orientation relative to the light's axes, so it changes as
+    // the camera rotates in place (no translation needed) - same frustum, different
+    // projected extent - which makes the box's size, its texel density, and any bias tuned
+    // against that size all drift with camera orientation. A frustum's bounding SPHERE has
+    // a radius that depends only on fov/aspect/near/far (all orientation-invariant), so a
+    // box sized to that sphere (same half-extent on every axis) stays a constant size no
+    // matter which way the camera looks - only its center moves. X/Y center is then snapped
+    // to whole shadow-map texels so the box doesn't sub-texel-jitter as the camera moves
+    // (standard stable-fit stabilization).
+    ShadowBoxBounds computeLightSpaceBounds(
+        const std::array<glm::vec3, 8>& corners, const glm::mat4& lightView, float zMargin, int tileSize)
+    {
+        glm::vec3 centroid(0.0f);
+        for (const auto& c : corners) centroid += c;
+        centroid /= (float)corners.size();
+
+        float radius = 0.0f;
+        for (const auto& c : corners) radius = std::max(radius, glm::length(c - centroid));
+
+        glm::vec3 lc = glm::vec3(lightView * glm::vec4(centroid, 1.0f));
+
+        ShadowBoxBounds b;
+        b.minX = lc.x - radius - kShadowBoxXYMargin; b.maxX = lc.x + radius + kShadowBoxXYMargin;
+        b.minY = lc.y - radius - kShadowBoxXYMargin; b.maxY = lc.y + radius + kShadowBoxXYMargin;
+        b.minZ = lc.z - radius - zMargin;            b.maxZ = lc.z + radius + zMargin;
+
+        if (tileSize > 0)
+        {
+            float sizeX = b.maxX - b.minX;
+            float sizeY = b.maxY - b.minY;
+            float texelX = sizeX / (float)tileSize;
+            float texelY = sizeY / (float)tileSize;
+            if (texelX > 0.0f)
+            {
+                float centerX = std::floor(((b.minX + b.maxX) * 0.5f) / texelX) * texelX;
+                b.minX = centerX - sizeX * 0.5f;
+                b.maxX = centerX + sizeX * 0.5f;
+            }
+            if (texelY > 0.0f)
+            {
+                float centerY = std::floor(((b.minY + b.maxY) * 0.5f) / texelY) * texelY;
+                b.minY = centerY - sizeY * 0.5f;
+                b.maxY = centerY + sizeY * 0.5f;
+            }
+        }
+        return b;
+    }
 }
 
 GL_Deferred_Renderer::GL_Deferred_Renderer()
@@ -264,6 +351,42 @@ std::vector<EntityID> GL_Deferred_Renderer::queryEntitiesNear(const glm::vec3& p
     }
 }
 
+std::vector<EntityID> GL_Deferred_Renderer::queryEntitiesInCone(const glm::vec3& apex, const glm::vec3& direction,
+    float halfAngleRadians, float maxDistance)
+{
+    if (!m_Messenger) return {};
+
+    ECXRequest request;
+    request.type = ECXRequestType::ConeCheck;
+    request.args[0] = apex;
+    request.args[1] = direction;
+    request.args[2] = halfAngleRadians;
+    request.args[3] = maxDistance;
+    request.args[4] = static_cast<uint32_t>(CollisionLayers::Renderable);
+    request.args[5] = true;  // castsShadowOnly
+    request.args[6] = false; // checkOcclusion - a caster behind another still needs to
+                              // render into the depth map, unlike a visibility/interaction
+                              // cone check where an occluded candidate should be excluded.
+
+    ECXResponse response;
+    m_Messenger->publish(request, response);
+
+    if (response.response != ECXResponseType::Success || response.responseData.empty())
+        return {};
+
+    try {
+        const auto& hits = std::any_cast<std::vector<RayQueryHit>>(response.responseData[0]);
+        std::vector<EntityID> result;
+        result.reserve(hits.size());
+        for (const auto& hit : hits)
+            result.push_back(hit.entity);
+        return result;
+    }
+    catch (const std::bad_any_cast&) {
+        return {};
+    }
+}
+
 void GL_Deferred_Renderer::geometryPass(EC_GameScene& scene)
 {
     auto& manager = EC_DOD_EntityManager::getInstance();
@@ -389,7 +512,6 @@ void GL_Deferred_Renderer::updateLights(EC_GameScene& scene)
     m_ShadowDirs.clear();
     m_ShadowSpots.clear();
     m_ShadowPoints.clear();
-    m_ShadowSpotRadii.clear();
     m_ShadowPointRadii.clear();
     m_ShadowDirIDs.clear();
     m_ShadowSpotIDs.clear();
@@ -400,6 +522,12 @@ void GL_Deferred_Renderer::updateLights(EC_GameScene& scene)
     for (EntityID entityID : scene.getLights()) {
         if (!manager.isAlive(entityID)) continue;
         if (!manager.hasComponent<EC_DOD_Light>(entityID)) continue;
+        // A deactivated light (EntityAPI::deactivate(), e.g. a debug light-cycling script)
+        // must stop contributing entirely - matches the same EC_DOD_EntityInfo::active check
+        // EC_BroadPhase::broadPhaseCollisionDetection() already does for scene-deactivation.
+        if (manager.hasComponent<EC_DOD_EntityInfo>(entityID) &&
+            !manager.getComponent<EC_DOD_EntityInfo>(entityID).active)
+            continue;
 
         const auto& light = manager.getComponent<EC_DOD_Light>(entityID);
 
@@ -425,7 +553,6 @@ void GL_Deferred_Renderer::updateLights(EC_GameScene& scene)
             if (!light.castsShadow) m_Spots.push_back(data);
             else {
                 m_ShadowSpots.push_back(data);
-                m_ShadowSpotRadii.push_back(light.cutoffRadius);
                 m_ShadowSpotIDs.push_back(entityID);
             }
         }
@@ -456,19 +583,55 @@ void GL_Deferred_Renderer::bakeStaticShadows(EC_GameScene& scene)
     // matters more than efficiency for a one-time operation.
     std::vector<EntityID> allEntities = scene.getEntities();
 
-    for (size_t i = 0; i < m_ShadowDirs.size(); i++)
+    // A static (dynamic=false) directional light's box is fit once, here, to wherever the
+    // scene's active camera is at load time - then never touched again (see the
+    // "Directional shadow: camera-following frustum fit" plan's Dynamic-flag contract:
+    // static means baked once and trusted forever, not kept in sync with a roaming camera).
+    bool haveCamera = false;
+    glm::mat4 camView(1.0f);
+    glm::vec3 camPos(0.0f);
+    float camFov = 60.0f, camNear = 1.0f, aspect = 1.0f;
+    for (EntityID cameraID : scene.getCameras())
     {
-        EntityID id = m_ShadowDirIDs[i];
-        if (m_BakedStaticDirLights.count(id)) continue;
-        if (!manager.isAlive(id) || !manager.hasComponent<EC_DOD_Light>(id)) continue;
-        if (manager.getComponent<EC_DOD_Light>(id).dynamic) continue;
+        if (!manager.isAlive(cameraID)) continue;
+        const auto& camera = manager.getComponent<EC_DOD_Camera>(cameraID);
+        if (!camera.isActive) continue;
+        const auto& spatial = manager.getComponent<EC_DOD_Spatial>(cameraID);
+        camView = camera.viewMatrix;
+        camPos = spatial.position;
+        camFov = camera.fov;
+        camNear = camera.nearPlane;
+        aspect = (float)m_Window->getWidth() / m_Window->getHeight();
+        haveCamera = true;
+        break;
+    }
 
-        glm::mat4 shadowTransform;
-        shadowDirPass(id, m_ShadowDirs[i], allEntities, shadowTransform);
-        if (m_ShadowAtlas.hasTile(id))
+    if (haveCamera)
+    {
+        for (size_t i = 0; i < m_ShadowDirs.size(); i++)
         {
-            m_BakedStaticDirLights.insert(id);
-            m_BakedDirShadowTransforms[id] = shadowTransform;
+            EntityID id = m_ShadowDirIDs[i];
+            if (m_BakedStaticDirLights.count(id)) continue;
+            if (!manager.isAlive(id) || !manager.hasComponent<EC_DOD_Light>(id)) continue;
+            if (manager.getComponent<EC_DOD_Light>(id).dynamic) continue;
+
+            glm::mat4 shadowTransform;
+            ShadowBoxBounds bounds;
+            int drawn = shadowDirPass(id, m_ShadowDirs[i], allEntities, camView, camPos, camFov, aspect, camNear, shadowTransform, bounds);
+            // bakeStaticShadows() runs exactly once per scene (EC_SceneManager, right as it
+            // finishes loading) - permanently caching a bake where nothing actually drew
+            // (mesh handles not finalized yet, this early after scene load) would leave the
+            // light silently unshadowed forever with no way to retry. Leaving it out of the
+            // baked set here means shadowLightingPass()'s per-frame loop falls through to the
+            // ordinary dynamic-light soft-bake path instead (which does retry every frame) -
+            // effectively degrading a failed static bake to dynamic rather than losing the
+            // shadow outright.
+            if (m_ShadowAtlas.hasTile(id) && drawn > 0)
+            {
+                m_BakedStaticDirLights.insert(id);
+                m_BakedDirShadowTransforms[id] = shadowTransform;
+                m_BakedDirShadowBounds[id] = bounds;
+            }
         }
     }
 
@@ -480,8 +643,8 @@ void GL_Deferred_Renderer::bakeStaticShadows(EC_GameScene& scene)
         if (manager.getComponent<EC_DOD_Light>(id).dynamic) continue;
 
         glm::mat4 shadowTransform;
-        shadowSpotPass(id, m_ShadowSpots[i], allEntities, shadowTransform);
-        if (m_ShadowAtlas.hasTile(id))
+        int drawn = shadowSpotPass(id, m_ShadowSpots[i], allEntities, shadowTransform);
+        if (m_ShadowAtlas.hasTile(id) && drawn > 0)
         {
             m_BakedStaticSpotLights.insert(id);
             m_BakedSpotShadowTransforms[id] = shadowTransform;
@@ -503,9 +666,10 @@ void GL_Deferred_Renderer::bakeStaticShadows(EC_GameScene& scene)
     }
 }
 
-void GL_Deferred_Renderer::renderShadowCasters(const glm::mat4& view, const glm::mat4& projection, const std::vector<EntityID>& entities)
+int GL_Deferred_Renderer::renderShadowCasters(const glm::mat4& view, const glm::mat4& projection, const std::vector<EntityID>& entities)
 {
     auto& manager = EC_DOD_EntityManager::getInstance();
+    int drawn = 0;
 
     for (EntityID entityID : entities) {
         if (!manager.isAlive(entityID)) continue;
@@ -525,12 +689,17 @@ void GL_Deferred_Renderer::renderShadowCasters(const glm::mat4& view, const glm:
         glBindVertexArray(gfx.getMeshHandle());
         glDrawElements(GL_TRIANGLES, gfx.getVertexCount(), GL_UNSIGNED_INT, 0);
         glBindVertexArray(0);
+        drawn++;
     }
+
+    return drawn;
 }
 
-void GL_Deferred_Renderer::shadowDirPass(EntityID lightID, DirLightData& light, const std::vector<EntityID>& entities, glm::mat4& outShadowTransform)
+int GL_Deferred_Renderer::shadowDirPass(EntityID lightID, DirLightData& light, const std::vector<EntityID>& entities,
+    const glm::mat4& camView, const glm::vec3& camPos, float camFov, float aspect, float camNear,
+    glm::mat4& outShadowTransform, ShadowBoxBounds& outBounds)
 {
-    if (!m_ShadowAtlas.acquireTile(lightID)) return;
+    if (!m_ShadowAtlas.acquireTile(lightID)) return 0;
 
     glm::vec3 eye = glm::vec3(-light.direction);
     glm::vec3 up;
@@ -538,27 +707,49 @@ void GL_Deferred_Renderer::shadowDirPass(EntityID lightID, DirLightData& light, 
     up[1] = eye[2] - eye[0];
     up[2] = eye[0] - eye[1];
 
-    glm::mat4 view = glm::lookAt(eye, glm::vec3(0.0f), up);
-    glm::mat4 projection = glm::ortho(-20.0f, 20.0f, -20.0f, 20.0f, -10.0f, 20.0f);
+    // Eye is offset from the camera (not the world origin) along the light's direction -
+    // only fixes *where* the view matrix is anchored, not its orientation, which still
+    // comes entirely from `eye`/`up` as before. See "Directional shadow: camera-following
+    // frustum fit" plan - the old glm::lookAt(eye, glm::vec3(0.0f), up) anchored the whole
+    // frustum at the world origin regardless of where the camera or its content actually was.
+    glm::mat4 view = glm::lookAt(camPos + eye * m_ShadowQueryRadius, camPos, up);
+
+    auto corners = computeCameraFrustumCorners(camView, camFov, aspect, camNear, m_RenderConfig.dirShadowDistance);
+    ShadowBoxBounds bounds = computeLightSpaceBounds(corners, view, kShadowBoxZMargin, m_ShadowAtlas.getTileSize());
+    outBounds = bounds;
+
+    // glm::lookAt's view space has -Z forward, so a closer point has a larger (less
+    // negative) view-space Z - glm::ortho's near/far are positive distances along -Z, so
+    // near = -maxZ (closest) and far = -minZ (farthest).
+    glm::mat4 projection = glm::ortho(bounds.minX, bounds.maxX, bounds.minY, bounds.maxY, -bounds.maxZ, -bounds.minZ);
     outShadowTransform = m_ShadowAtlas.getTileBiasMatrix(lightID) * projection * view;
 
-    glEnable(GL_POLYGON_OFFSET_FILL);
-    glPolygonOffset(2.0, 2.0);
-    glCullFace(GL_FRONT);
+    // Bias lives entirely on the READ side now (DirLightShadowPBR.frag's computeOcclusion,
+    // slope-scaled against the receiving surface - see learnopengl.com/Advanced-Lighting/
+    // Shadows/Shadow-Mapping, which uses no glPolygonOffset at all for exactly this reason).
+    // No write-side glPolygonOffset here, and no front-face culling either - front-face
+    // culling is ITSELF a (cruder, geometric) bias technique: it deliberately records the
+    // far/back surface instead of the near one as an implicit offset. Stacking it on top of
+    // the new read-side bias is the same double-biasing mistake as the glPolygonOffset one,
+    // and the reference tutorial explicitly warns front-face culling "may still give
+    // incorrect results" for a caster close to its receiver - exactly the contact-point gap
+    // seen here. Render normally (GL_BACK, the frame's default) and let the read-side bias
+    // be the only bias mechanism.
     m_ShadowAtlas.bindTileForWriting(lightID);
 
-    renderShadowCasters(view, projection, entities);
+    int drawn = renderShadowCasters(view, projection, entities);
 
     glUseProgram(0);
     m_ShadowAtlas.unbindTileForWriting();
     glEnable(GL_CULL_FACE);
     glDisable(GL_POLYGON_OFFSET_FILL);
     glCullFace(GL_BACK);
+    return drawn;
 }
 
-void GL_Deferred_Renderer::shadowSpotPass(EntityID lightID, SpotLightData& light, const std::vector<EntityID>& entities, glm::mat4& outShadowTransform)
+int GL_Deferred_Renderer::shadowSpotPass(EntityID lightID, SpotLightData& light, const std::vector<EntityID>& entities, glm::mat4& outShadowTransform)
 {
-    if (!m_ShadowAtlas.acquireTile(lightID)) return;
+    if (!m_ShadowAtlas.acquireTile(lightID)) return 0;
 
     glm::vec3 position = light.position;
     glm::vec3 direction = light.direction;
@@ -575,18 +766,25 @@ void GL_Deferred_Renderer::shadowSpotPass(EntityID lightID, SpotLightData& light
     glm::mat4 projection = glm::perspective(2.0f * light.cutoffAngle, 1.0f, m_SpotShadowNearPlane, m_SpotShadowFarPlane);
     outShadowTransform = m_ShadowAtlas.getTileBiasMatrix(lightID) * projection * view;
 
+    // No front-face culling here (unlike the original) - for a near-overhead spot and a
+    // short caster, the "back" (far-from-light) face front-culling would record is the
+    // object's underside, nearly coplanar with the floor it's supposedly occluding -
+    // producing almost no usable depth difference to compare against, which reads as no
+    // shadow at all. Same lesson as the directional-light fix earlier this session.
+    // glPolygonOffset stays - a genuinely different, complementary technique (slope-scaled
+    // depth-buffer bias, not "which surface gets recorded").
     glEnable(GL_POLYGON_OFFSET_FILL);
     glPolygonOffset(2.0, 2.0);
-    glCullFace(GL_FRONT);
     m_ShadowAtlas.bindTileForWriting(lightID);
 
-    renderShadowCasters(view, projection, entities);
+    int drawn = renderShadowCasters(view, projection, entities);
 
     glUseProgram(0);
     m_ShadowAtlas.unbindTileForWriting();
     glEnable(GL_CULL_FACE);
     glDisable(GL_POLYGON_OFFSET_FILL);
     glCullFace(GL_BACK);
+    return drawn;
 }
 
 void GL_Deferred_Renderer::shadowPointPass(EntityID lightID, LightData& light, const std::vector<EntityID>& entities)
@@ -809,6 +1007,7 @@ void GL_Deferred_Renderer::shadowLightingPass(EC_GameScene& scene)
             m_BakedStaticDirLights.erase(evicted);
             m_BakedStaticSpotLights.erase(evicted);
             m_BakedDirShadowTransforms.erase(evicted);
+            m_BakedDirShadowBounds.erase(evicted);
             m_BakedSpotShadowTransforms.erase(evicted);
         }
         for (EntityID evicted : m_PointShadowPool.reconcile(m_ShadowPointIDs))
@@ -816,16 +1015,34 @@ void GL_Deferred_Renderer::shadowLightingPass(EC_GameScene& scene)
             m_BakedStaticPointLights.erase(evicted);
         }
 
+        float aspect = (float)m_Window->getWidth() / m_Window->getHeight();
+
         auto dirCasters = queryEntitiesNear(spatial.position, m_ShadowQueryRadius);
         for (size_t i = 0; i < m_ShadowDirs.size(); i++)
         {
             EntityID id = m_ShadowDirIDs[i];
             glm::mat4 shadowTransform;
+            ShadowBoxBounds activeBounds;
             bool baked = m_BakedStaticDirLights.count(id) != 0;
             if (baked)
+            {
                 shadowTransform = m_BakedDirShadowTransforms.at(id);
+                activeBounds = m_BakedDirShadowBounds.at(id);
+            }
             else
-                shadowDirPass(id, m_ShadowDirs[i], dirCasters, shadowTransform);
+            {
+                // Always re-render for dynamic=true lights - no soft-bake caching. A caching
+                // scheme was attempted here (skip re-render when the camera's view is still
+                // covered by the last box and nothing nearby is moving) but proved unsafe in
+                // practice: the caster query can stabilize its *count* before the underlying
+                // entities are actually fully populated (mesh handles finalize a frame or two
+                // behind broad-phase indexing), so a render could report a plausible non-zero
+                // "drew something" result while still missing some of the real casters -
+                // caching that wrong result then never gets corrected, since nothing in a
+                // static scene invalidates it afterward. Unconditional per-frame rendering is
+                // always correct; revisit caching later with a more robust readiness check.
+                shadowDirPass(id, m_ShadowDirs[i], dirCasters, camView, spatial.position, camera.fov, aspect, camera.nearPlane, shadowTransform, activeBounds);
+            }
             if (!m_ShadowAtlas.hasTile(id)) continue; // atlas full, skip this light entirely this frame
 
             m_ShadowDirLightShader.activate();
@@ -835,6 +1052,11 @@ void GL_Deferred_Renderer::shadowLightingPass(EC_GameScene& scene)
             m_ShadowDirLightShader.setUniform("WSCamPos", spatial.position);
             m_ShadowDirLightShader.setDirLight("dirLight", m_ShadowDirs[i]);
             m_ShadowDirLightShader.setUniform("ShadowTransform", shadowTransform);
+            // Read-side, slope-scaled bias (see DirLightShadowPBR.frag's computeOcclusion) needs
+            // to know the box's actual world-space depth span to convert a world-space bias
+            // into the right NDC offset - this varies with the camera-fit frustum, unlike the
+            // old fixed ~30-unit box, so it can't be a shader constant.
+            m_ShadowDirLightShader.setUniform("ShadowDepthRange", activeBounds.maxZ - activeBounds.minZ);
             m_ShadowDirLightShader.bindTexture("shadowMap", 5, m_ShadowAtlas.getDepthTexture());
             renderQuad();
             glDisable(GL_BLEND);
@@ -845,13 +1067,30 @@ void GL_Deferred_Renderer::shadowLightingPass(EC_GameScene& scene)
         for (size_t i = 0; i < m_ShadowSpots.size(); i++)
         {
             EntityID id = m_ShadowSpotIDs[i];
-            auto nearby = queryEntitiesNear(glm::vec3(m_ShadowSpots[i].position), m_ShadowSpotRadii[i]);
+            // A spot's influence is a cone, not a sphere - queryEntitiesNear's sphere-center
+            // test both over-includes (candidates behind the light within the radius) and
+            // under-includes (a large caster whose bounds cross into the cone but whose own
+            // center falls outside it). queryEntitiesInCone runs the exact GJK cone-vs-shape
+            // test EC_BroadPhase already uses for interaction cone checks (see
+            // RayConeClickTest.lua), so partial overlaps are correctly included.
+            auto nearby = queryEntitiesInCone(glm::vec3(m_ShadowSpots[i].position), glm::vec3(m_ShadowSpots[i].direction),
+                m_ShadowSpots[i].cutoffAngle, m_SpotShadowFarPlane);
             glm::mat4 shadowTransform;
             bool baked = m_BakedStaticSpotLights.count(id) != 0;
             if (baked)
                 shadowTransform = m_BakedSpotShadowTransforms.at(id);
             else
+            {
+                // Always re-render for dynamic=true lights - no soft-bake caching. See the
+                // identical note in the directional loop above for why: a caching scheme
+                // here proved unsafe in practice (a render can report a plausible non-zero
+                // "drew something" result while still missing some real casters, if the
+                // caster query's count stabilizes before every entity's mesh handle actually
+                // finalizes - and that wrong result then never self-corrects). Unconditional
+                // per-frame rendering is always correct; revisit caching later with a more
+                // robust readiness check.
                 shadowSpotPass(id, m_ShadowSpots[i], nearby, shadowTransform);
+            }
             if (!m_ShadowAtlas.hasTile(id)) continue; // atlas full, skip this light entirely this frame
 
             m_ShadowSpotLightShader.activate();
@@ -877,7 +1116,14 @@ void GL_Deferred_Renderer::shadowLightingPass(EC_GameScene& scene)
             auto nearby = queryEntitiesNear(glm::vec3(m_ShadowPoints[i].position), m_ShadowPointRadii[i]);
             bool baked = m_BakedStaticPointLights.count(id) != 0;
             if (!baked)
+            {
+                // Always re-render for dynamic=true lights - no soft-bake caching. See the
+                // identical note in shadowLightingPass()'s directional/spot loops for why:
+                // a caching scheme here has the same unexercised risk (a render could report
+                // success while still missing casters whose mesh handles hadn't finished GPU
+                // upload yet, and that wrong result would never self-correct afterward).
                 shadowPointPass(id, m_ShadowPoints[i], nearby);
+            }
             if (!m_PointShadowPool.hasSlot(id)) continue; // pool full, skip this light entirely this frame
 
             m_ShadowPointLightShader.activate();

--- a/src/Graphics/Renderers/GL_Deferred_Renderer.h
+++ b/src/Graphics/Renderers/GL_Deferred_Renderer.h
@@ -28,6 +28,15 @@ enum class PostProcess {
 class EC_GameScene;
 class ECXMessenger;
 
+// Light-space AABB of a directional shadow's camera-fitted ortho box, used both to build
+// the box itself and (for dynamic=true lights) to test whether a later frame's camera
+// frustum still fits inside a previous render - see GL_Deferred_Renderer::shadowDirPass.
+struct ShadowBoxBounds {
+    float minX = 0.0f, maxX = 0.0f;
+    float minY = 0.0f, maxY = 0.0f;
+    float minZ = 0.0f, maxZ = 0.0f;
+};
+
 class GL_Deferred_Renderer : public Renderer, public ICommandListener {
 public:
     GL_Deferred_Renderer();
@@ -53,9 +62,24 @@ private:
     // call - only the view/projection construction differs between the two callers, which
     // they each keep). shadowPointPass's 6-face loop is structurally different enough that
     // forcing it into this helper would hurt readability more than it would help.
-    void renderShadowCasters(const glm::mat4& view, const glm::mat4& projection, const std::vector<EntityID>& entities);
-    void shadowDirPass(EntityID lightID, DirLightData& light, const std::vector<EntityID>& entities, glm::mat4& outShadowTransform);
-    void shadowSpotPass(EntityID lightID, SpotLightData& light, const std::vector<EntityID>& entities, glm::mat4& outShadowTransform);
+    // Returns how many casters were actually drawn (passed every filter: alive, has
+    // Transform/GraphicsData, mesh handle finalized, castsShadow) - NOT just entities.size().
+    // A caster's mesh handle can still be 0 for a frame or two after it starts appearing in
+    // spatial queries (GPU resource finalization lags a frame behind broad-phase indexing),
+    // so entities.size() > 0 alone doesn't mean anything was actually rendered - callers
+    // that cache a render need this to avoid caching an effectively-empty one.
+    int renderShadowCasters(const glm::mat4& view, const glm::mat4& projection, const std::vector<EntityID>& entities);
+    // Builds the ortho box by fitting it to the camera's current view frustum (clamped to
+    // RenderConfig::dirShadowDistance) instead of a fixed world-space box - see the
+    // "Directional shadow: camera-following frustum fit" plan. outBounds is the light-space
+    // AABB the box was built from, so callers can later test whether a new camera frustum
+    // is still covered by it without re-rendering (the dynamic-light soft-bake check).
+    // Return value: same "how many casters were actually drawn" as renderShadowCasters, or
+    // 0 if the tile couldn't be acquired.
+    int shadowDirPass(EntityID lightID, DirLightData& light, const std::vector<EntityID>& entities,
+        const glm::mat4& camView, const glm::vec3& camPos, float camFov, float aspect, float camNear,
+        glm::mat4& outShadowTransform, ShadowBoxBounds& outBounds);
+    int shadowSpotPass(EntityID lightID, SpotLightData& light, const std::vector<EntityID>& entities, glm::mat4& outShadowTransform);
     void shadowPointPass(EntityID lightID, LightData& light, const std::vector<EntityID>& entities);
     // Issue #28: redraws just the receivesShadow==false entities among `entities` with this
     // light's full (unshadowed) contribution, depth-testing GL_EQUAL against the G-buffer so
@@ -79,6 +103,12 @@ private:
     // owning/maintaining its own - decouples rendering from collision internals.
     std::vector<EntityID> queryVisibleEntities(const glm::mat4& viewProjection);
     std::vector<EntityID> queryEntitiesNear(const glm::vec3& position, float radius);
+    // Exact GJK cone-vs-shape test (EC_BroadPhase::handleConeCheck), not a bounding-sphere
+    // approximation - a spot light's actual influence is a cone, not a sphere, and this
+    // returns every caster whose shape overlaps it at all (partial overlap included, not
+    // just fully-contained), matching what queryEntitiesNear's sphere-center check missed.
+    std::vector<EntityID> queryEntitiesInCone(const glm::vec3& apex, const glm::vec3& direction,
+        float halfAngleRadians, float maxDistance);
 
     ECXMessenger* m_Messenger = nullptr;
     RenderConfig m_RenderConfig;
@@ -150,12 +180,15 @@ private:
     std::unordered_set<EntityID> m_BakedStaticSpotLights;
     std::unordered_set<EntityID> m_BakedStaticPointLights;
     std::unordered_map<EntityID, glm::mat4> m_BakedDirShadowTransforms;
+    std::unordered_map<EntityID, ShadowBoxBounds> m_BakedDirShadowBounds;
     std::unordered_map<EntityID, glm::mat4> m_BakedSpotShadowTransforms;
-    // Cached cutoff radius for each entry in m_ShadowPoints/m_ShadowSpots, indices
-    // aligned 1:1. Copied from EC_DOD_Light::cutoffRadius in updateLights() - not
-    // recomputed here, since the radius only depends on light data set at load time.
+
+    // Cached cutoff radius for each entry in m_ShadowPoints, indices aligned 1:1.
+    // Copied from EC_DOD_Light::cutoffRadius in updateLights() - not recomputed here,
+    // since the radius only depends on light data set at load time. Spot's equivalent
+    // caster query now uses queryEntitiesInCone (the light's own cutoffAngle/far plane),
+    // not a radius.
     std::vector<float> m_ShadowPointRadii;
-    std::vector<float> m_ShadowSpotRadii;
     GL_DebugRenderer m_DebugRenderer;
     GL_UIRenderer m_UIRenderer;
 };

--- a/src/Graphics/Renderers/RenderConfig.h
+++ b/src/Graphics/Renderers/RenderConfig.h
@@ -9,4 +9,8 @@ struct RenderConfig
     int shadowAtlasTileSize = 1024;
     int pointShadowPoolSize = 6;
     int pointShadowFaceSize = 1024;
+    // How far along the camera's view the directional-light shadow frustum reaches -
+    // deliberately less than the camera's own draw distance, to keep shadow-map texel
+    // density reasonable (see GL_Deferred_Renderer::shadowDirPass).
+    float dirShadowDistance = 50.0f;
 };

--- a/src/Graphics/Shaders/Shader.cpp
+++ b/src/Graphics/Shaders/Shader.cpp
@@ -70,6 +70,18 @@ bool Shader::loadShader(const std::string & vertFile, const std::string & fragFi
 	glLinkProgram(m_Shader);
 	error = glGetError();
 
+	int linked = 0;
+	glGetProgramiv(m_Shader, GL_LINK_STATUS, &linked);
+	if (!linked)
+	{
+		outputShaderError(m_Shader);
+		glDeleteShader(vert);
+		glDeleteShader(frag);
+		delete[] vs;
+		delete[] fs;
+		return false;
+	}
+
 	delete vs;
 	delete fs;
 

--- a/src/xml/XML.h
+++ b/src/xml/XML.h
@@ -324,6 +324,11 @@ namespace XML
 				const char* faceSize = child->Attribute("faceSize");
 				if (faceSize) settings.pointShadowFaceSize = std::stoi(faceSize);
 			}
+			else if (strcmp(child->Value(), "DirShadow") == 0)
+			{
+				const char* distance = child->Attribute("distance");
+				if (distance) settings.dirShadowDistance = std::stof(distance);
+			}
 			child = child->NextSiblingElement();
 		}
 		return true;


### PR DESCRIPTION
…d-side bias

The reported shadow "peter-panning" traced back to shadowDirPass() anchoring the directional light's ortho box at the world origin regardless of camera position - fine for a small scene, badly wrong for LargeYard's 270-unit yard. Fixing it properly surfaced several compounding issues along the way:

- Directional shadow box now fits the camera's view frustum each frame, sized via a bounding sphere (not a raw AABB of the frustum corners) so it stays orientation-invariant as the camera rotates in place.
- Shadow bias moved from write-side hacks (glPolygonOffset magnitude, front-face culling as an implicit offset) to read-side, slope-scaled bias in the fragment shader, matching the standard shadow-mapping technique - the two are not interchangeable, and stacking them was the source of the acne/peter-panning tug-of-war.
- Spot light's caster query switched from a sphere-center test (queryEntitiesNear) to an exact cone-vs-shape GJK test (queryEntitiesInCone, reusing EC_BroadPhase's existing ConeCheck), so partial overlaps are no longer missed.
- Found and fixed a real, previously-silent bug: shadow.vert's uniform locations collided with the "Exempt" shadow shaders' G-buffer sampler locations, so those shaders had never actually linked - Shader::loadShader now checks GL_LINK_STATUS instead of swallowing the failure.
- Removed the soft-bake caching optimization for dynamic-light shadows (directional/spot/point all now re-render every frame): a render could report success while still missing casters whose mesh handles hadn't finished GPU upload yet, and a scene with nothing else moving would never self-correct the resulting stale cache.
- New minimal ShadowDebug.xml scene (registered as the "shadowdebug" alias) for isolating shadow-rendering bugs from unrelated multi-caster clutter, with an L key light-cycle debug control consolidated into one script (DebugSceneKeyDown.lua) to avoid two scripts colliding on the same global Lua function name.