### PR TITLE
Fix point-light shadow detachment via read-side slope-scaled bias

### DIFF
--- a/data/assets/shaders/PointShadowLightPass.frag
+++ b/data/assets/shaders/PointShadowLightPass.frag
@@ -96,14 +96,19 @@ vec3 computeLight(
     return (kD * albedo / PI + specular) * radiance * NdotL;
 }
 
-float computeOcclusion(vec3 fragPos, vec3 lightPos)
+float computeOcclusion(vec3 fragPos, vec3 lightPos, vec3 normal)
 {
+    // Read-side bias only - see shadowPointPass()'s comment for why a write-side
+    // glPolygonOffset/front-face-culling bias doesn't work here. Slope-scaled against the
+    // receiving surface (steeper angle to the light needs more bias), same approach as
+    // DirLightShadowPBR.frag/SpotlightShadowPBR.frag, just directly in world-space distance
+    // units since this cubemap already stores linear light-distance rather than NDC depth.
     vec3 fragToLight   = fragPos - lightPos;
     float closestDepth = texture(shadowMap, fragToLight).r * FarPlane;
     float currentDepth = length(fragToLight);
-    float bias         = 0.05;
+    vec3 lightDir      = normalize(-fragToLight);
+    float bias         = mix(0.15, 0.02, max(dot(normal, lightDir), 0.0));
     return (currentDepth - bias > closestDepth) ? 0.2 : 1.0;
-    //return closestDepth;
 }
 
 void main()
@@ -116,7 +121,7 @@ void main()
 
     vec3 vToEye    = normalize(WSCamPos - pcolour.xyz);
     vec3 ltf       = pointLight.position.xyz - pcolour.xyz;
-    float visibility = computeOcclusion(pcolour.xyz, pointLight.position.xyz);
+    float visibility = computeOcclusion(pcolour.xyz, pointLight.position.xyz, ncolour.rgb);
 
     vec3 fragCol = computeLight(
         normalize(ltf),

--- a/src/Graphics/Renderers/GL_Deferred_Renderer.cpp
+++ b/src/Graphics/Renderers/GL_Deferred_Renderer.cpp
@@ -806,10 +806,14 @@ void GL_Deferred_Renderer::shadowPointPass(EntityID lightID, LightData& light, c
         glm::lookAt(lightPos, lightPos + glm::vec3(0, 0,-1), glm::vec3(0,-1, 0))
     };
 
-    glEnable(GL_POLYGON_OFFSET_FILL);
-    glPolygonOffset(2.0, 2.0);
-    glCullFace(GL_FRONT);
-
+    // No write-side glPolygonOffset here - point_shadow.frag writes gl_FragDepth manually
+    // (linear light-distance / FarPlane), which overrides the hardware-rasterized depth
+    // glPolygonOffset would have biased, so it had zero effect. No front-face culling
+    // either, for the same reason removed from the directional/spot passes: recording the
+    // far (light-facing-away) surface instead of the near one is itself a crude geometric
+    // bias, and for a caster close to its receiver that gap reads as the shadow detaching
+    // from the object. Render normally (GL_BACK, the frame's default) and let the read-side
+    // slope-scaled bias in PointShadowLightPass.frag's computeOcclusion be the only bias.
     auto& manager = EC_DOD_EntityManager::getInstance();
 
     for (int face = 0; face < 6; face++)


### PR DESCRIPTION
shadowPointPass used front-face culling plus a write-side glPolygonOffset that had no actual effect, since point_shadow.frag writes gl_FragDepth manually and overrides any hardware depth bias. Front-face culling alone was recording the caster's far surface instead of its near one, producing a visible gap between the object and its shadow. Removed both write-side techniques and replaced the flat 0.05 read-side bias in PointShadowLightPass.frag with a slope-scaled one, matching the approach already used for directional and spot shadows.