### PR TITLE
Add entity-per-chunk voxel terrain streaming, fix shutdown deadlock a…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ add_executable(ECX_UnitTests
     tests/EC_SpatialGrid_Tests.cpp
     tests/EC_Frustum_Tests.cpp
     tests/EC_MarchingCubes_Tests.cpp
+    tests/EC_TerrainWorldDensity_Tests.cpp
     src/Engine/Subsystems/CollisionSystems/EC_GJK.cpp
     src/Engine/Subsystems/CollisionSystems/EC_ConvexSupport.cpp
     src/Engine/Subsystems/CollisionSystems/EC_CollisionChecks.cpp
@@ -175,6 +176,7 @@ add_executable(ECX_UnitTests
     src/Spatial/EC_Frustum.cpp
     src/Terrain/EC_MarchingCubesTables.cpp
     src/Terrain/EC_MarchingCubesMesher.cpp
+    src/Terrain/EC_TerrainWorldDensity.cpp
 )
 set_property(TARGET ECX_UnitTests PROPERTY CXX_STANDARD 17)
 target_include_directories(ECX_UnitTests PRIVATE ${SOURCE_DIR})

--- a/data/scripts/XML/Scenes.XML
+++ b/data/scripts/XML/Scenes.XML
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <Scenes>
-	<Scene alias="shadowdebug" precache="true" unloadondeactivate="false">data/scripts/XML/ShadowDebug.xml</Scene>
+	<Scene alias="voxelchunkdemo" precache="true" unloadondeactivate="false">data/scripts/XML/VoxelChunkDemo.xml</Scene>
+	<Scene alias="shadowdebug" precache="false" unloadondeactivate="false">data/scripts/XML/ShadowDebug.xml</Scene>
 	<Scene alias="yard" precache="false" unloadondeactivate="false">data/scripts/XML/LargeYard.xml</Scene>
 	<Scene alias="physics_demo" precache="false" unloadondeactivate="false">data/scripts/XML/PhysicsDemo.xml</Scene>
 	<Scene alias="main" precache="false" unloadondeactivate="false">data/scripts/XML/Scene1.xml</Scene>

--- a/data/scripts/XML/VoxelChunkDemo.xml
+++ b/data/scripts/XML/VoxelChunkDemo.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<Scene>
+	<Manifest>
+		<HDR alias="nightsky">data/assets/Images/Skybox/qwantani_moon_noon_puresky_4k.hdr</HDR>
+		<LuaScript alias="keydown">data/scripts/LUA/DebugSceneKeyDown.lua</LuaScript>
+		<LuaScript alias="keyup">data/scripts/LUA/OnKeyUp.lua</LuaScript>
+		<LuaScript alias="keyheld">data/scripts/LUA/OnKeyHeld.lua</LuaScript>
+		<LuaScript alias="mousemove">data/scripts/LUA/onMouseMove.lua</LuaScript>
+	</Manifest>
+
+	<!-- Verification scene for EC_VoxelChunkSystem (see the "Voxel terrain: entity-per-
+	     chunk streaming integration" plan) - the chunk grid itself is NOT authored here;
+	     EC_VoxelChunkSystem::init() spawns it unconditionally (a permanent subsystem, not
+	     scene-gated), so this scene only needs a camera, light, and skybox to view it. -->
+
+	<Entity uid="400" name="voxelchunk_skybox">
+		<Skybox>
+			<HDR alias="nightsky"/>
+		</Skybox>
+	</Entity>
+
+	<Entity uid="401" name="voxelchunk_camera">
+		<Camera>
+			<FOV>60.0</FOV>
+			<DrawDistance>300.0</DrawDistance>
+		</Camera>
+		<Spatial>
+			<Position>0.0,25.0,-60.0</Position>
+			<Orientation>0.0,0.0,0.0</Orientation>
+		</Spatial>
+		<ScriptComponent>
+			<OnKeyDown alias="keydown"/>
+			<OnKeyUp alias="keyup"/>
+			<OnKeyHeld alias="keyheld"/>
+			<OnMouseMove alias="mousemove"/>
+		</ScriptComponent>
+	</Entity>
+
+	<Entity uid="402" name="voxelchunk_sun">
+		<Light>
+			<Type>Directional</Type>
+			<Direction>0.3,-1.0,0.2,0.0</Direction>
+			<Colour>1.0,1.0,1.0,1.0</Colour>
+			<Intensity>1.0</Intensity>
+			<CastsShadow>false</CastsShadow>
+			<Dynamic>false</Dynamic>
+		</Light>
+	</Entity>
+</Scene>

--- a/src/Components/EC_DOD_Components.h
+++ b/src/Components/EC_DOD_Components.h
@@ -163,6 +163,16 @@ struct EC_DOD_GraphicsData {
     uint32_t getVertexCount() const { return model ? model->getVertCount() : 0; }
 };
 
+// A voxel terrain chunk entity - the real, permanent integration (see
+// EC_VoxelChunkSystem/EC_VoxelChunkWorker), not debug scaffolding. `state` tracks the
+// async generate-then-upload lifecycle: Pending (spawned, not yet queued for generation),
+// Generating (queued/running on the worker thread), Ready (mesh uploaded, collider added).
+struct EC_DOD_VoxelChunk {
+    enum class State { Pending, Generating, Ready };
+    glm::ivec3 chunkCoord{ 0 };
+    State state = State::Pending;
+};
+
 struct EC_DOD_Camera {
     glm::mat4 viewMatrix{ 1.0f };
     glm::mat4 projectionMatrix{ 1.0f };

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -44,6 +44,7 @@ Game_Error EC_Game::init(const std::string& configurationFilename)
 
     m_Timer = std::make_unique<Timer>();
     m_threadmanager.init(8);
+    m_VoxelChunkSystem.init(m_Messenger, *this);
     m_Running = true;
     m_Messenger.Subscribe(*this, ECXCommandType::SystemShutdown);
     LOGGING::ECX_Logger::GetInstance()->LogMessage("Init complete", LOGGING::LogLevel::INFORMATION);
@@ -130,6 +131,9 @@ void EC_Game::update(const float& deltaTimeS)
     if (m_Running)
     {
         m_Messenger.flush();
+        // Before scene update/render so a chunk finishing this frame is visible this
+        // frame rather than one frame late.
+        m_VoxelChunkSystem.update(deltaTimeS, *this);
         m_SceneManager.update(deltaTimeS, *this);
         m_Controls->update(deltaTimeS, *this);
         m_UIInput.update(*this, m_Messenger);
@@ -225,6 +229,7 @@ void EC_Game::receive(ECXCommand& command)
     {
         m_Running = false;
         m_Controls->shutdown();
+        m_VoxelChunkSystem.shutdown();
         m_threadmanager.stop();
     }
 }

--- a/src/Game.h
+++ b/src/Game.h
@@ -13,6 +13,7 @@
 #include "Engine/Controllers/MouseButton.h"
 #include "UI/EC_UI_InputSystem.h"
 #include "Spatial/RayQueryHit.h"
+#include "Terrain/EC_VoxelChunkSystem.h"
 #include <glm/glm.hpp>
 
 enum class Game_Error
@@ -69,6 +70,7 @@ private:
     bool m_Running;
     EC_UI_InputSystem m_UIInput;
     EC_ThreadManager m_threadmanager;
+    EC_VoxelChunkSystem m_VoxelChunkSystem;
     std::mutex m_lock;
     void receive(ECXCommand& command) override;
 };

--- a/src/Terrain/CMakeLists.txt
+++ b/src/Terrain/CMakeLists.txt
@@ -5,4 +5,10 @@ target_sources(ECX PRIVATE
     EC_MarchingCubesTables.cpp
     EC_MarchingCubesMesher.h
     EC_MarchingCubesMesher.cpp
+    EC_TerrainWorldDensity.h
+    EC_TerrainWorldDensity.cpp
+    EC_VoxelChunkWorker.h
+    EC_VoxelChunkWorker.cpp
+    EC_VoxelChunkSystem.h
+    EC_VoxelChunkSystem.cpp
 )

--- a/src/Terrain/EC_MarchingCubesMesher.cpp
+++ b/src/Terrain/EC_MarchingCubesMesher.cpp
@@ -217,6 +217,99 @@ void weldVertices(EC_TerrainMeshData& mesh)
     mesh = std::move(welded);
 }
 
+// Splits each cube into 6 tetrahedra sharing the cube's main space diagonal (corner 0 to
+// corner 6), the standard decomposition that keeps every cube in a uniform grid sliced the
+// same way - so two cubes sharing a face always agree on that face's diagonal and the
+// surface stitches with no possibility of a crack, unlike the flat 256-case cube table
+// this replaced. That table is topologically ambiguous for certain corner configurations
+// (some cube cases admit two different, mutually inconsistent triangulations of a shared
+// face; the table always picks one, and an adjacent cube can legally pick the other),
+// which is what left the scattered interior holes the diagnostic test caught - see
+// tests/EC_TerrainWorldDensity_Tests.cpp's "no non-manifold (hole) edges" case. A
+// tetrahedron's isosurface has no such ambiguity: a linear field over 4 points crosses an
+// isovalue in only one possible way per corner-sign pattern (derived below, not
+// table-driven, so there's no transcription-error surface for a bug to hide in).
+constexpr int kTetraCorners[6][4] = {
+    {0, 1, 2, 6}, {0, 2, 3, 6}, {0, 3, 7, 6},
+    {0, 7, 4, 6}, {0, 4, 5, 6}, {0, 5, 1, 6},
+};
+
+// Fixes winding the same way the old cube-table path did: pick whichever ordering of the
+// triangle's own vertex-normal average, since the gradient-based normals are already known
+// to point outward. This matters more here, not less - the tetrahedron cases below are
+// derived from data flow, not by hand-checking each triangle's handedness.
+void emitTriangle(const EC_DensityField& field, EC_TerrainMeshData& mesh,
+    glm::vec3 p0, glm::vec3 p1, glm::vec3 p2)
+{
+    glm::vec3 n0 = computeNormal(field, p0);
+    glm::vec3 n1 = computeNormal(field, p1);
+    glm::vec3 n2 = computeNormal(field, p2);
+
+    glm::vec3 windingNormal = glm::cross(p1 - p0, p2 - p0);
+    glm::vec3 avgNormal = n0 + n1 + n2;
+    if (glm::dot(windingNormal, avgNormal) < 0.0f) {
+        std::swap(p1, p2);
+        std::swap(n1, n2);
+    }
+
+    mesh.positions.push_back(p0); mesh.normals.push_back(n0);
+    mesh.positions.push_back(p1); mesh.normals.push_back(n1);
+    mesh.positions.push_back(p2); mesh.normals.push_back(n2);
+    uint32_t base = static_cast<uint32_t>(mesh.positions.size()) - 3;
+    mesh.indices.push_back(base); mesh.indices.push_back(base + 1); mesh.indices.push_back(base + 2);
+}
+
+// Polygonises one tetrahedron given its 4 corner positions/values (already resolved from
+// the parent cube's 8 corners via kTetraCorners). Every one of the 16 corner-inside
+// patterns is one of exactly 3 shapes - empty, a single vertex cut off (1 or 3 corners
+// inside), or a planar quad cut (2 and 2) - so the whole case table is this direct
+// classification rather than a hardcoded 16-row lookup.
+void polygoniseTetrahedron(const EC_DensityField& field, EC_TerrainMeshData& mesh, float isoLevel,
+    const glm::vec3 p[4], const float v[4])
+{
+    int inside = 0;
+    for (int c = 0; c < 4; c++)
+        if (v[c] < isoLevel) inside |= (1 << c);
+
+    int count = (inside & 1) + ((inside >> 1) & 1) + ((inside >> 2) & 1) + ((inside >> 3) & 1);
+    if (count == 0 || count == 4) return;
+
+    if (count == 1 || count == 3) {
+        // The one corner whose inside/outside state differs from the other three.
+        int apex = -1;
+        for (int c = 0; c < 4; c++) {
+            bool cIsInside = (inside & (1 << c)) != 0;
+            if ((count == 1) == cIsInside) { apex = c; break; }
+        }
+        glm::vec3 cut[3];
+        int slot = 0;
+        for (int c = 0; c < 4; c++) {
+            if (c == apex) continue;
+            cut[slot++] = vertexInterp(isoLevel, p[apex], p[c], v[apex], v[c]);
+        }
+        emitTriangle(field, mesh, cut[0], cut[1], cut[2]);
+        return;
+    }
+
+    // count == 2: two corners inside, two outside - the cross-section is a quadrilateral
+    // with one corner cut from each of the 4 (inside, outside) pairs. Going P(i0,o0),
+    // P(i0,o1), P(i1,o1), P(i1,o0) walks the quad's actual edge loop (each consecutive pair
+    // shares a tetrahedron vertex - i0, then o1, then i1, then o0), so splitting it along
+    // its own diagonal (i0,o0)-(i1,o1) gives two triangles rather than a bowtie.
+    int i0 = -1, i1 = -1, o0 = -1, o1 = -1;
+    for (int c = 0; c < 4; c++) {
+        bool cIsInside = (inside & (1 << c)) != 0;
+        if (cIsInside) { if (i0 < 0) i0 = c; else i1 = c; }
+        else { if (o0 < 0) o0 = c; else o1 = c; }
+    }
+    glm::vec3 q00 = vertexInterp(isoLevel, p[i0], p[o0], v[i0], v[o0]);
+    glm::vec3 q01 = vertexInterp(isoLevel, p[i0], p[o1], v[i0], v[o1]);
+    glm::vec3 q11 = vertexInterp(isoLevel, p[i1], p[o1], v[i1], v[o1]);
+    glm::vec3 q10 = vertexInterp(isoLevel, p[i1], p[o0], v[i1], v[o0]);
+    emitTriangle(field, mesh, q00, q01, q11);
+    emitTriangle(field, mesh, q00, q11, q10);
+}
+
 } // namespace
 
 EC_TerrainMeshData polygonise(const EC_DensityField& field, float isoLevel)
@@ -236,46 +329,10 @@ EC_TerrainMeshData polygonise(const EC_DensityField& field, float isoLevel)
                     cornerVal[c] = field.sample(cx, cy, cz);
                 }
 
-                int cubeIndex = 0;
-                for (int c = 0; c < 8; c++)
-                    if (cornerVal[c] < isoLevel) cubeIndex |= (1 << c);
-
-                const int* row = EC_MarchingCubesTables::kTriangleTable[cubeIndex];
-                if (row[0] < 0) continue;
-
-                for (int i = 0; i < 13 && row[i] >= 0; i += 3) {
-                    glm::vec3 triPos[3];
-                    glm::vec3 triNormal[3];
-                    for (int corner = 0; corner < 3; corner++) {
-                        int edge = row[i + corner];
-                        int a = EC_MarchingCubesTables::kCubeEdgeCorners[edge][0];
-                        int b = EC_MarchingCubesTables::kCubeEdgeCorners[edge][1];
-                        triPos[corner] = vertexInterp(isoLevel, cornerPos[a], cornerPos[b], cornerVal[a], cornerVal[b]);
-                        triNormal[corner] = computeNormal(field, triPos[corner]);
-                    }
-
-                    // The table's case rows don't all share one consistent winding
-                    // direction (some cube configurations emit CW, others CCW, relative to
-                    // the surface's actual outward side) - left as-is, the renderer's
-                    // backface culling would then remove a different, camera-angle-
-                    // dependent subset of triangles across the mesh, which looks exactly
-                    // like a lighting boundary that rotates with the camera (culling
-                    // happens before the fragment shader runs, so no shading fix could
-                    // have masked or revealed this). Correct it per-triangle: if the
-                    // geometric winding normal disagrees with the vertex normals (already
-                    // proven correctly outward-facing), swap two corners to flip it.
-                    glm::vec3 windingNormal = glm::cross(triPos[1] - triPos[0], triPos[2] - triPos[0]);
-                    glm::vec3 avgNormal = triNormal[0] + triNormal[1] + triNormal[2];
-                    if (glm::dot(windingNormal, avgNormal) < 0.0f) {
-                        std::swap(triPos[1], triPos[2]);
-                        std::swap(triNormal[1], triNormal[2]);
-                    }
-
-                    for (int corner = 0; corner < 3; corner++) {
-                        mesh.positions.push_back(triPos[corner]);
-                        mesh.normals.push_back(triNormal[corner]);
-                        mesh.indices.push_back(static_cast<uint32_t>(mesh.positions.size() - 1));
-                    }
+                for (const auto& tet : kTetraCorners) {
+                    glm::vec3 tetPos[4] = { cornerPos[tet[0]], cornerPos[tet[1]], cornerPos[tet[2]], cornerPos[tet[3]] };
+                    float tetVal[4] = { cornerVal[tet[0]], cornerVal[tet[1]], cornerVal[tet[2]], cornerVal[tet[3]] };
+                    polygoniseTetrahedron(field, mesh, isoLevel, tetPos, tetVal);
                 }
             }
         }

--- a/src/Terrain/EC_TerrainWorldDensity.cpp
+++ b/src/Terrain/EC_TerrainWorldDensity.cpp
@@ -1,0 +1,25 @@
+#include "Terrain/EC_TerrainWorldDensity.h"
+#include <cmath>
+
+namespace EC_TerrainWorldDensity {
+
+namespace {
+    constexpr float kBaseHeight = 10.0f;
+    constexpr float kAmplitude = 3.0f;
+}
+
+float sampleWorldDensity(const glm::vec3& worldPos)
+{
+    // Same rolling-hills formula as the original single-chunk verification field, just
+    // evaluated at world-space X/Z instead of chunk-local coordinates - sin/cos are
+    // globally continuous, so any two chunks sampling this function at the same world
+    // position (their shared boundary/halo) get the identical value, with no chunk
+    // ever needing to know about its neighbours' own data.
+    float height = kBaseHeight
+        + kAmplitude * std::sin(worldPos.x * 0.25f) * std::cos(worldPos.z * 0.2f)
+        + 0.5f * kAmplitude * std::sin(worldPos.x * 0.6f + 1.3f) * std::sin(worldPos.z * 0.5f);
+
+    return worldPos.y - height;
+}
+
+} // namespace EC_TerrainWorldDensity

--- a/src/Terrain/EC_TerrainWorldDensity.h
+++ b/src/Terrain/EC_TerrainWorldDensity.h
@@ -1,0 +1,15 @@
+#pragma once
+#include <glm/glm.hpp>
+
+// World-space density function shared by every chunk - pure C++/glm, no engine
+// dependency, same testability bar as EC_MarchingCubesMesher itself. Any chunk builds its
+// own EC_DensityField (interior + 1-voxel halo) by sampling this ONE function at
+// `chunkOrigin + localOffset`; since two adjacent chunks sample the identical function at
+// matching world positions in their overlap/halo region, their meshes agree exactly at
+// the shared boundary with no cross-chunk data exchange needed. Negative = solid,
+// positive = open, matching EC_DensityField's documented convention.
+namespace EC_TerrainWorldDensity {
+
+float sampleWorldDensity(const glm::vec3& worldPos);
+
+} // namespace EC_TerrainWorldDensity

--- a/src/Terrain/EC_VoxelChunkSystem.cpp
+++ b/src/Terrain/EC_VoxelChunkSystem.cpp
@@ -1,0 +1,117 @@
+#include "Terrain/EC_VoxelChunkSystem.h"
+#include "Terrain/EC_VoxelChunkWorker.h"
+#include "Terrain/EC_TerrainMeshData.h"
+#include "Components/EC_DOD_Components.h"
+#include "Components/EC_CollisionLayers.h"
+#include "Entity/EC_DOD_EntityManager.h"
+#include "Graphics/Models/ObjModel.h"
+#include "Graphics/Shaders/Shader.h"
+#include "Logging/ECX_Logging.h"
+
+namespace {
+    // Small fixed grid, one Y layer - enough to prove multiple chunks stitch together
+    // seamlessly without a distance-based streaming trigger yet (deferred to a later
+    // slice, along with LOD).
+    constexpr int kGridRadius = 1; // chunks from -1..1 in X and Z => 3x3
+
+    // Chunks finishing several at once (e.g. right after startup) would spike a frame if
+    // all uploaded in one go - matches the throttling rationale behind
+    // EC_DOD_EntityFactory::finalizePendingGraphics(maxPerCall).
+    constexpr int kMaxUploadsPerFrame = 2;
+}
+
+EC_VoxelChunkSystem::EC_VoxelChunkSystem() {
+}
+
+EC_VoxelChunkSystem::~EC_VoxelChunkSystem() {
+    shutdown();
+}
+
+void EC_VoxelChunkSystem::shutdown() {
+    if (m_Worker) m_Worker->shutdown();
+}
+
+void EC_VoxelChunkSystem::init(ECXMessenger& messenger, EC_Game& game) {
+    m_ChunkShader = std::make_shared<Shader>();
+    if (!m_ChunkShader->loadShader("data/assets/shaders/basic.vert", "data/assets/shaders/PBR.frag")) {
+        LOGGING::ECX_Logger::GetInstance()->LogMessage(
+            "EC_VoxelChunkSystem: failed to load chunk shader", LOGGING::LogLevel::CRITICAL);
+        return;
+    }
+
+    m_Worker = std::make_shared<EC_VoxelChunkWorker>();
+    m_ThreadManager.addTask(m_Worker);
+    m_ThreadManager.executeTasks();
+
+    auto& manager = EC_DOD_EntityManager::getInstance();
+
+    for (int x = -kGridRadius; x <= kGridRadius; x++) {
+        for (int z = -kGridRadius; z <= kGridRadius; z++) {
+            glm::ivec3 coord(x, 0, z);
+
+            EntityID entity = manager.createEntity();
+
+            EC_DOD_Spatial spatial;
+            spatial.position = glm::vec3(coord) * static_cast<float>(kChunkWorldSize);
+            manager.addComponent(entity, spatial);
+
+            EC_DOD_Transform transform;
+            manager.addComponent(entity, transform);
+
+            EC_DOD_GraphicsData gfx;
+            gfx.shader = m_ChunkShader;
+            gfx.colour = glm::vec4(0.5f, 0.45f, 0.35f, 1.0f);
+            manager.addComponent(entity, gfx);
+
+            EC_DOD_VoxelChunk chunk;
+            chunk.chunkCoord = coord;
+            chunk.state = EC_DOD_VoxelChunk::State::Generating;
+            manager.addComponent(entity, chunk);
+
+            m_Worker->scheduleChunk(coord, entity);
+        }
+    }
+}
+
+void EC_VoxelChunkSystem::update(const float& deltaTimeS, EC_Game& game) {
+    if (!m_Worker) return;
+
+    auto& manager = EC_DOD_EntityManager::getInstance();
+
+    for (int i = 0; i < kMaxUploadsPerFrame; i++) {
+        EntityID entity;
+        EC_TerrainMeshData meshData;
+        if (!m_Worker->tryDrainCompleted(entity, meshData)) break;
+
+        if (!manager.isAlive(entity)) continue;
+        if (!manager.hasComponent<EC_DOD_GraphicsData>(entity)) continue;
+        if (!manager.hasComponent<EC_DOD_VoxelChunk>(entity)) continue;
+        if (meshData.positions.empty()) continue;
+
+        auto model = std::make_shared<ObjModel>();
+        model->initialiseFromMeshData(meshData);
+
+        auto& gfx = manager.getComponent<EC_DOD_GraphicsData>(entity);
+        gfx.model = model;
+
+        // Renderable so EC_BroadPhase's spatial index (and thus frustum culling) can find
+        // this entity at all - constructEntity() does this automatically for XML-authored
+        // entities, but chunks bypass that path entirely. Left collidable (default mask)
+        // rather than mask=0 (render-only) since a chunk is meant to be a real, solid
+        // piece of ground once gameplay collision exists - not yet exercised by the
+        // current free-fly debug camera, which has no physics body of its own.
+        EC_DOD_Collider collider;
+        collider.type = EC_DOD_Collider::Type::AABB;
+        float half = static_cast<float>(kChunkWorldSize) * 0.5f;
+        collider.extents = glm::vec3(half);
+        collider.center = glm::vec3(half);
+        collider.collisionLayer |= CollisionLayers::Renderable;
+        manager.addComponent(entity, collider);
+
+        manager.getComponent<EC_DOD_VoxelChunk>(entity).state = EC_DOD_VoxelChunk::State::Ready;
+
+        LOGGING::ECX_Logger::GetInstance()->LogMessage(
+            "EC_VoxelChunkSystem: chunk ready (" + std::to_string(meshData.positions.size()) + " vertices)",
+            LOGGING::LogLevel::INFORMATION);
+    }
+}

--- a/src/Terrain/EC_VoxelChunkSystem.h
+++ b/src/Terrain/EC_VoxelChunkSystem.h
@@ -1,0 +1,37 @@
+#pragma once
+#include <memory>
+#include "Engine/Subsystems/EC_System.h"
+#include "TaskManager/EC_ThreadManager.h"
+
+class EC_VoxelChunkWorker;
+class Shader;
+
+// The real, permanent voxel chunk integration - a fixed grid of chunk entities, each
+// generated off the main thread (EC_VoxelChunkWorker) and uploaded on the main thread
+// here. NOT wired into EC_PhysicsThreadTask's system list like Spatial/Transform/Camera/
+// Scripting: those all run update() on the physics/background thread, but this system's
+// update() does real GL work (ObjModel::initialiseFromMeshData) finishing each chunk, so
+// it's called directly from EC_Game::update() instead - see that method for the call site,
+// guaranteed main-thread since it also calls Window::present() right after.
+class EC_VoxelChunkSystem : public EC_System {
+public:
+    // One voxel = one world unit; chunks are cubes of this size on a side. Referenced by
+    // EC_VoxelChunkWorker when it builds each chunk's density field at coord * this.
+    static constexpr int kChunkWorldSize = 32;
+
+    EC_VoxelChunkSystem();
+    virtual ~EC_VoxelChunkSystem();
+
+    virtual void init(ECXMessenger& messenger, EC_Game& game) override;
+    virtual void update(const float& deltaTimeS, EC_Game& game) override;
+
+    // Must be called before EC_ThreadManager::stop() joins the shared pool - the worker's
+    // execute() loop only exits once this notifies it, otherwise the join deadlocks on a
+    // thread parked in the worker's own condvar wait.
+    void shutdown();
+
+private:
+    EC_ThreadManager m_ThreadManager;
+    std::shared_ptr<EC_VoxelChunkWorker> m_Worker;
+    std::shared_ptr<Shader> m_ChunkShader;
+};

--- a/src/Terrain/EC_VoxelChunkWorker.cpp
+++ b/src/Terrain/EC_VoxelChunkWorker.cpp
@@ -1,0 +1,82 @@
+#include "Terrain/EC_VoxelChunkWorker.h"
+#include "Terrain/EC_DensityField.h"
+#include "Terrain/EC_MarchingCubesMesher.h"
+#include "Terrain/EC_TerrainWorldDensity.h"
+#include "Terrain/EC_VoxelChunkSystem.h"
+
+EC_VoxelChunkWorker::EC_VoxelChunkWorker()
+    : m_Running(true)
+{
+}
+
+EC_VoxelChunkWorker::~EC_VoxelChunkWorker() {
+    shutdown();
+}
+
+void EC_VoxelChunkWorker::scheduleChunk(const glm::ivec3& chunkCoord, EntityID entity) {
+    {
+        std::lock_guard<std::mutex> lock(m_QueueMutex);
+        m_JobQueue.push_back({ chunkCoord, entity });
+    }
+    m_QueueCV.notify_one();
+}
+
+void EC_VoxelChunkWorker::shutdown() {
+    m_Running = false;
+    {
+        std::lock_guard<std::mutex> lock(m_QueueMutex);
+        m_JobQueue.clear();
+    }
+    m_QueueCV.notify_one();
+}
+
+bool EC_VoxelChunkWorker::tryDrainCompleted(EntityID& outEntity, EC_TerrainMeshData& outMesh) {
+    std::lock_guard<std::mutex> lock(m_CompletedMutex);
+    if (m_CompletedQueue.empty()) return false;
+
+    CompletedChunk& front = m_CompletedQueue.front();
+    outEntity = front.entity;
+    outMesh = std::move(front.meshData);
+    m_CompletedQueue.pop_front();
+    return true;
+}
+
+void EC_VoxelChunkWorker::execute() {
+    while (m_Running) {
+        ChunkJob job;
+        bool hasJob = false;
+        {
+            std::unique_lock<std::mutex> lock(m_QueueMutex);
+            m_QueueCV.wait(lock, [this] { return !m_Running || !m_JobQueue.empty(); });
+            if (!m_Running) break;
+            job = m_JobQueue.front();
+            m_JobQueue.pop_front();
+            hasJob = true;
+        }
+        if (!hasJob) continue;
+
+        glm::vec3 chunkOrigin(
+            static_cast<float>(job.chunkCoord.x) * EC_VoxelChunkSystem::kChunkWorldSize,
+            static_cast<float>(job.chunkCoord.y) * EC_VoxelChunkSystem::kChunkWorldSize,
+            static_cast<float>(job.chunkCoord.z) * EC_VoxelChunkSystem::kChunkWorldSize);
+
+        EC_DensityField field(EC_VoxelChunkSystem::kChunkWorldSize);
+        int size = field.interiorSize;
+        for (int z = -EC_DensityField::Padding; z < size + EC_DensityField::Padding; z++) {
+            for (int y = -EC_DensityField::Padding; y < size + EC_DensityField::Padding; y++) {
+                for (int x = -EC_DensityField::Padding; x < size + EC_DensityField::Padding; x++) {
+                    glm::vec3 worldPos = chunkOrigin + glm::vec3(
+                        static_cast<float>(x), static_cast<float>(y), static_cast<float>(z));
+                    field.at(x, y, z) = EC_TerrainWorldDensity::sampleWorldDensity(worldPos);
+                }
+            }
+        }
+
+        EC_TerrainMeshData meshData = EC_MarchingCubesMesher::polygonise(field, 0.0f);
+
+        {
+            std::lock_guard<std::mutex> lock(m_CompletedMutex);
+            m_CompletedQueue.push_back({ job.entity, std::move(meshData) });
+        }
+    }
+}

--- a/src/Terrain/EC_VoxelChunkWorker.h
+++ b/src/Terrain/EC_VoxelChunkWorker.h
@@ -1,0 +1,50 @@
+#pragma once
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <glm/glm.hpp>
+#include "Entity/EC_DOD_EntityManager.h"
+#include "TaskManager/EC_Task.h"
+#include "Terrain/EC_TerrainMeshData.h"
+
+// Off-thread chunk mesh generation, shaped like EC_DOD_LoadingWorker (see that class for
+// the precedent this mirrors): a long-lived EC_Task added once to the shared thread pool,
+// whose execute() loops on its own job queue for the life of the program. Unlike the
+// loading worker's single "ready to finalize" flag (suited to one batch finishing
+// together), chunks complete independently and at different times, so results are
+// reported through a queue the main thread drains one at a time each frame.
+class EC_VoxelChunkWorker : public EC_Task {
+public:
+    EC_VoxelChunkWorker();
+    ~EC_VoxelChunkWorker();
+
+    // Producer side (main thread): queue a chunk for generation.
+    void scheduleChunk(const glm::ivec3& chunkCoord, EntityID entity);
+
+    // Consumer side (main thread): pops one completed chunk's result if any are ready.
+    // Returns false (leaving outEntity/outMesh untouched) if nothing has finished yet.
+    bool tryDrainCompleted(EntityID& outEntity, EC_TerrainMeshData& outMesh);
+
+    void shutdown();
+    void execute() override;
+
+private:
+    struct ChunkJob {
+        glm::ivec3 chunkCoord;
+        EntityID entity;
+    };
+    struct CompletedChunk {
+        EntityID entity;
+        EC_TerrainMeshData meshData;
+    };
+
+    std::atomic<bool> m_Running;
+
+    std::mutex m_QueueMutex;
+    std::condition_variable m_QueueCV;
+    std::deque<ChunkJob> m_JobQueue;
+
+    std::mutex m_CompletedMutex;
+    std::deque<CompletedChunk> m_CompletedQueue;
+};

--- a/tests/EC_TerrainWorldDensity_Tests.cpp
+++ b/tests/EC_TerrainWorldDensity_Tests.cpp
@@ -1,0 +1,120 @@
+// Unit tests for EC_TerrainWorldDensity - pure C++/glm, no engine dependency. The one
+// property that actually matters for chunk streaming: two chunks built by sampling this
+// shared function at their own world offsets must agree exactly where they touch.
+#include <catch2/catch_test_macros.hpp>
+#include <unordered_map>
+#include "Terrain/EC_DensityField.h"
+#include "Terrain/EC_MarchingCubesMesher.h"
+#include "Terrain/EC_TerrainWorldDensity.h"
+
+namespace {
+
+EC_DensityField buildChunkField(const glm::vec3& chunkOrigin, int interiorSize)
+{
+    EC_DensityField field(interiorSize);
+    for (int z = -EC_DensityField::Padding; z < interiorSize + EC_DensityField::Padding; z++) {
+        for (int y = -EC_DensityField::Padding; y < interiorSize + EC_DensityField::Padding; y++) {
+            for (int x = -EC_DensityField::Padding; x < interiorSize + EC_DensityField::Padding; x++) {
+                glm::vec3 worldPos = chunkOrigin + glm::vec3(
+                    static_cast<float>(x), static_cast<float>(y), static_cast<float>(z));
+                field.at(x, y, z) = EC_TerrainWorldDensity::sampleWorldDensity(worldPos);
+            }
+        }
+    }
+    return field;
+}
+
+} // namespace
+
+TEST_CASE("EC_TerrainWorldDensity produces a non-empty mesh for a chunk-sized field", "[TerrainWorldDensity]") {
+    EC_DensityField field = buildChunkField(glm::vec3(0.0f), 32);
+    EC_TerrainMeshData mesh = EC_MarchingCubesMesher::polygonise(field, 0.0f);
+
+    REQUIRE(!mesh.positions.empty());
+    REQUIRE(mesh.indices.size() % 3 == 0);
+}
+
+TEST_CASE("DIAGNOSTIC: interior mesh has no non-manifold (hole) edges", "[TerrainWorldDensity][.diagnostic]") {
+    constexpr int chunkSize = 32;
+    EC_DensityField field = buildChunkField(glm::vec3(0.0f), chunkSize);
+    EC_TerrainMeshData mesh = EC_MarchingCubesMesher::polygonise(field, 0.0f);
+
+    auto onChunkBoundary = [&](const glm::vec3& p) {
+        constexpr float eps = 0.01f;
+        return p.x < eps || p.x > chunkSize - eps
+            || p.y < eps || p.y > chunkSize - eps
+            || p.z < eps || p.z > chunkSize - eps;
+    };
+
+    struct EdgeKey {
+        glm::vec3 a, b;
+        bool operator==(const EdgeKey& o) const { return a == o.a && b == o.b; }
+    };
+    struct EdgeHash {
+        size_t operator()(const EdgeKey& k) const {
+            auto h = std::hash<float>();
+            size_t seed = h(k.a.x) ^ h(k.a.y) ^ h(k.a.z) ^ h(k.b.x) ^ h(k.b.y) ^ h(k.b.z);
+            return seed;
+        }
+    };
+    auto quantize = [](const glm::vec3& v) {
+        constexpr float q = 4096.0f;
+        return glm::vec3(std::round(v.x * q) / q, std::round(v.y * q) / q, std::round(v.z * q) / q);
+    };
+    auto makeEdge = [&](glm::vec3 a, glm::vec3 b) {
+        a = quantize(a); b = quantize(b);
+        if (b.x < a.x || (b.x == a.x && (b.y < a.y || (b.y == a.y && b.z < a.z)))) std::swap(a, b);
+        return EdgeKey{ a, b };
+    };
+
+    std::unordered_map<EdgeKey, int, EdgeHash> edgeCount;
+    size_t triCount = mesh.indices.size() / 3;
+    for (size_t t = 0; t < triCount; t++) {
+        glm::vec3 p0 = mesh.positions[mesh.indices[t * 3 + 0]];
+        glm::vec3 p1 = mesh.positions[mesh.indices[t * 3 + 1]];
+        glm::vec3 p2 = mesh.positions[mesh.indices[t * 3 + 2]];
+        edgeCount[makeEdge(p0, p1)]++;
+        edgeCount[makeEdge(p1, p2)]++;
+        edgeCount[makeEdge(p2, p0)]++;
+    }
+
+    int interiorNonManifoldEdges = 0;
+    for (auto& [edge, count] : edgeCount) {
+        if (count != 2 && !onChunkBoundary(edge.a) && !onChunkBoundary(edge.b)) {
+            interiorNonManifoldEdges++;
+        }
+    }
+
+    INFO("Interior non-manifold (odd-usage) edges found: " << interiorNonManifoldEdges);
+    REQUIRE(interiorNonManifoldEdges == 0);
+}
+
+TEST_CASE("EC_TerrainWorldDensity: adjacent chunks agree exactly at their shared boundary", "[TerrainWorldDensity]") {
+    constexpr int chunkSize = 32;
+    glm::vec3 originA(0.0f, 0.0f, 0.0f);
+    glm::vec3 originB(static_cast<float>(chunkSize), 0.0f, 0.0f); // neighbour along +X
+
+    EC_DensityField fieldA = buildChunkField(originA, chunkSize);
+    EC_DensityField fieldB = buildChunkField(originB, chunkSize);
+
+    EC_TerrainMeshData meshA = EC_MarchingCubesMesher::polygonise(fieldA, 0.0f);
+    EC_TerrainMeshData meshB = EC_MarchingCubesMesher::polygonise(fieldB, 0.0f);
+
+    REQUIRE(!meshA.positions.empty());
+    REQUIRE(!meshB.positions.empty());
+
+    // A vertex near chunk A's +X face (local x close to chunkSize) should, once shifted
+    // into chunk B's local space (its own world origin is chunkSize further along +X),
+    // match a vertex chunk B actually produced near its own -X face - both are sampling
+    // the identical world-space function at the identical world position.
+    bool foundMatchOnBoundary = false;
+    for (const glm::vec3& a : meshA.positions) {
+        if (a.x < chunkSize - 1.5f) continue;
+        glm::vec3 shifted = a - glm::vec3(static_cast<float>(chunkSize), 0.0f, 0.0f);
+        for (const glm::vec3& b : meshB.positions) {
+            if (glm::length(b - shifted) < 0.001f) { foundMatchOnBoundary = true; break; }
+        }
+        if (foundMatchOnBoundary) break;
+    }
+    REQUIRE(foundMatchOnBoundary);
+}


### PR DESCRIPTION
…nd mesh cracks

Replaces the throwaway single-entity terrain scaffolding with the real production path: each chunk is its own entity (EC_DOD_VoxelChunk), generated on a background worker thread (EC_VoxelChunkWorker, mirroring EC_DOD_LoadingWorker's pattern) from a shared world-space density function so neighbouring chunks agree exactly at their boundary, and uploaded on the main thread by EC_VoxelChunkSystem with its own AABB collider.

Along the way:
- Fixed a shutdown deadlock: EC_ThreadManager::stop() joins the shared worker pool, but the chunk worker's own run flag was only ever cleared from EC_VoxelChunkSystem's destructor - too late to unblock the join. Now EC_Game::receive() shuts the chunk system down first.
- Fixed scattered internal holes in the generated terrain mesh: the classic 256-case Marching Cubes table has topologically ambiguous cube configurations that a flat lookup can resolve inconsistently between neighbouring cubes. Replaced polygonise()'s cube-table lookup with a 6-tetrahedra-per-cube decomposition, which has no such ambiguity by construction. Added a diagnostic non-manifold-edge test that catches this class of bug.
- VoxelChunkDemo is now the default startup scene instead of ShadowDebug.