### PR TITLE
Add GET /screenshot?target=<name> G-buffer views - Issue #87 third slice

### DIFF
--- a/src/Engine/Debug/EC_DebugHTTPServer.cpp
+++ b/src/Engine/Debug/EC_DebugHTTPServer.cpp
@@ -35,8 +35,9 @@ EC_DebugHTTPServer::EC_DebugHTTPServer(std::string host, int port)
     // GL/main thread - requestCapture() bridges this handler's own thread (one of
     // httplib's worker threads) to the main thread via the mutex+condvar rendezvous
     // below, serviced once per frame from EC_Game::update().
-    m_Server->Get("/screenshot", [this](const httplib::Request&, httplib::Response& res) {
-        std::vector<unsigned char> png = requestCapture();
+    m_Server->Get("/screenshot", [this](const httplib::Request& req, httplib::Response& res) {
+        std::string target = req.has_param("target") ? req.get_param_value("target") : "";
+        std::vector<unsigned char> png = requestCapture(target);
         if (png.empty()) {
             res.status = 503;
             res.set_content("screenshot capture failed or timed out", "text/plain");
@@ -66,7 +67,7 @@ void EC_DebugHTTPServer::shutdown() {
     if (m_Server) m_Server->stop();
 }
 
-std::vector<unsigned char> EC_DebugHTTPServer::requestCapture() {
+std::vector<unsigned char> EC_DebugHTTPServer::requestCapture(const std::string& target) {
     std::unique_lock<std::mutex> lock(m_CaptureMutex);
     // Serializes concurrent requesters behind each other rather than needing a real
     // multi-slot queue - see the class comment for why that's fine for this tool.
@@ -74,6 +75,7 @@ std::vector<unsigned char> EC_DebugHTTPServer::requestCapture() {
 
     m_CapturePending = true;
     m_CaptureResultReady = false;
+    m_CaptureTarget = target;
     m_CaptureResult.clear();
 
     bool completed = m_CaptureCV.wait_for(lock, std::chrono::seconds(5),
@@ -90,9 +92,11 @@ std::vector<unsigned char> EC_DebugHTTPServer::requestCapture() {
     return result;
 }
 
-bool EC_DebugHTTPServer::hasPendingCapture() {
+bool EC_DebugHTTPServer::hasPendingCapture(std::string& outTarget) {
     std::lock_guard<std::mutex> lock(m_CaptureMutex);
-    return m_CapturePending && !m_CaptureResultReady;
+    if (!m_CapturePending || m_CaptureResultReady) return false;
+    outTarget = m_CaptureTarget;
+    return true;
 }
 
 void EC_DebugHTTPServer::completeCapture(std::vector<unsigned char> pngBytes, bool ok) {

--- a/src/Engine/Debug/EC_DebugHTTPServer.h
+++ b/src/Engine/Debug/EC_DebugHTTPServer.h
@@ -29,18 +29,21 @@ public:
     // as EC_VoxelChunkSystem::shutdown() - see its own comment).
     void shutdown();
 
-    // GET /screenshot needs GL work (glReadPixels) that's only valid on the GL/main
-    // thread, but the handler runs on one of httplib's own worker threads - this is the
-    // single-slot rendezvous that bridges the two. Called from the HTTP handler thread:
-    // blocks until the main thread services the request (hasPendingCapture/
-    // completeCapture below) or ~5s elapses. A mutex-held single slot rather than a real
-    // queue - this is a low-traffic dev tool, not perf-sensitive, so concurrent requests
-    // simply serialize behind each other rather than needing real batching.
-    std::vector<unsigned char> requestCapture();
+    // GET /screenshot[?target=<name>] needs GL work (glReadPixels/glGetTexImage) that's
+    // only valid on the GL/main thread, but the handler runs on one of httplib's own
+    // worker threads - this is the single-slot rendezvous that bridges the two. Called
+    // from the HTTP handler thread: blocks until the main thread services the request
+    // (hasPendingCapture/completeCapture below) or ~5s elapses. A mutex-held single slot
+    // rather than a real queue - this is a low-traffic dev tool, not perf-sensitive, so
+    // concurrent requests simply serialize behind each other rather than needing real
+    // batching. `target` is passed straight through to Renderer::captureFrame - see its
+    // comment for the recognised names ("", "final", "albedo", "normal", "depth").
+    std::vector<unsigned char> requestCapture(const std::string& target);
 
     // Called from the main thread once per frame (see EC_Game::update()). Returns true
-    // if an HTTP thread is currently blocked in requestCapture() waiting on a result.
-    bool hasPendingCapture();
+    // (and fills outTarget) if an HTTP thread is currently blocked in requestCapture()
+    // waiting on a result.
+    bool hasPendingCapture(std::string& outTarget);
     // Called from the main thread right after producing (or failing to produce) the
     // capture hasPendingCapture() just reported - wakes the waiting HTTP thread.
     void completeCapture(std::vector<unsigned char> pngBytes, bool ok);
@@ -60,5 +63,6 @@ private:
     bool m_CapturePending = false;
     bool m_CaptureResultReady = false;
     bool m_CaptureOk = false;
+    std::string m_CaptureTarget;
     std::vector<unsigned char> m_CaptureResult;
 };

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -158,9 +158,10 @@ void EC_Game::update(const float& deltaTimeS)
         // (scene, skybox, debug overlay, UI) at this exact point. See
         // EC_DebugHTTPServer::requestCapture()'s comment for why this hand-off exists at
         // all (glReadPixels is only valid on this, the GL/main, thread).
-        if (m_DebugHTTPServer && m_DebugHTTPServer->hasPendingCapture()) {
+        std::string pendingCaptureTarget;
+        if (m_DebugHTTPServer && m_DebugHTTPServer->hasPendingCapture(pendingCaptureTarget)) {
             std::vector<unsigned char> pngBytes;
-            bool ok = m_SceneManager.captureFrame(pngBytes);
+            bool ok = m_SceneManager.captureFrame(pendingCaptureTarget, pngBytes);
             m_DebugHTTPServer->completeCapture(std::move(pngBytes), ok);
         }
 

--- a/src/Graphics/FrameBuffers/FrameBufferSet.h
+++ b/src/Graphics/FrameBuffers/FrameBufferSet.h
@@ -37,6 +37,7 @@ public:
 	void BindBloomUpsampleTarget(int level) { m_BloomChain.bindUpsampleTarget(level); }
 	void EndBloomChain();
 	unsigned int getGBufferDepthTexture() { return m_GBuffer.getDepthTexture(); }
+	unsigned int getGBufferTexture(FrameBufferType type) { return m_GBuffer.getGBufferTexture(type); }
 	unsigned int getFrameBuffer1Texture() { return m_FrameBuffer1.getBufferTexture(); }
 	~FrameBufferSet();
 private:

--- a/src/Graphics/Renderers/GL_Deferred_Renderer.cpp
+++ b/src/Graphics/Renderers/GL_Deferred_Renderer.cpp
@@ -17,6 +17,7 @@
 #include "UI/EC_UI_Components.h"
 #include "Graphics/Renderers/DebugVisualization.h"
 #include <algorithm>
+#include <cmath>
 #include <typeindex>
 #include <stb_image_write.h>
 #include <array>
@@ -1213,25 +1214,80 @@ namespace {
     }
 }
 
-bool GL_Deferred_Renderer::captureFrame(std::vector<unsigned char>& outPNGBytes)
+bool GL_Deferred_Renderer::captureFrame(const std::string& target, std::vector<unsigned char>& outPNGBytes)
 {
     // Must run on the GL/main thread, after this frame's rendering has all happened but
-    // before SDL_GL_SwapWindow() - see EC_Game::update()'s call site. Reading GL_BACK here
-    // (rather than the real backbuffer post-swap, which the issue's wording suggested) is
-    // the same pixels with none of the "just-swapped buffer contents are undefined on most
-    // drivers" fragility - this is what a viewer would see the instant it appears on screen,
-    // skybox/debug overlay/UI included (all drawn to this same default framebuffer before
-    // the swap).
+    // before SDL_GL_SwapWindow() - see EC_Game::update()'s call site.
     int width = m_Window->getWidth();
     int height = m_Window->getHeight();
     if (width <= 0 || height <= 0) return false;
 
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    glReadBuffer(GL_BACK);
+    constexpr int kChannels = 3; // always encode RGB, regardless of source format
+    size_t pixelCount = static_cast<size_t>(width) * height;
+    std::vector<unsigned char> pixels;
 
-    constexpr int kChannels = 3; // GL_RGB
-    std::vector<unsigned char> pixels(static_cast<size_t>(width) * height * kChannels);
-    glReadPixels(0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE, pixels.data());
+    if (target.empty() || target == "final") {
+        // Reading GL_BACK here (rather than the real backbuffer post-swap, which the
+        // issue's wording suggested) is the same pixels with none of the "just-swapped
+        // buffer contents are undefined on most drivers" fragility - this is what a
+        // viewer would see the instant it appears on screen, skybox/debug overlay/UI
+        // included (all drawn to this same default framebuffer before the swap).
+        glBindFramebuffer(GL_FRAMEBUFFER, 0);
+        glReadBuffer(GL_BACK);
+        pixels.resize(pixelCount * kChannels);
+        glReadPixels(0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE, pixels.data());
+    }
+    else if (target == "depth") {
+        // GL_DEPTH_COMPONENT32, single channel, already in [0,1] - but it's non-linear
+        // NDC depth (the classic 1/z falloff), not a linear distance, so nearby geometry
+        // reads much darker than the raw distance would suggest. Displayed as-is (no
+        // linearization) since that's the standard quick depth-debug convention.
+        std::vector<float> depth(pixelCount);
+        glBindTexture(GL_TEXTURE_2D, m_FrameBuffer.getGBufferDepthTexture());
+        glGetTexImage(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, GL_FLOAT, depth.data());
+        glBindTexture(GL_TEXTURE_2D, 0);
+
+        pixels.resize(pixelCount * kChannels);
+        for (size_t i = 0; i < pixelCount; i++) {
+            unsigned char v = static_cast<unsigned char>(std::clamp(depth[i], 0.0f, 1.0f) * 255.0f);
+            pixels[i * 3 + 0] = v;
+            pixels[i * 3 + 1] = v;
+            pixels[i * 3 + 2] = v;
+        }
+    }
+    else if (target == "albedo" || target == "normal") {
+        // Both attachments are GL_RGBA32F - raw linear data, not display-ready.
+        FrameBufferType type = (target == "albedo") ? FrameBufferType::Albedo : FrameBufferType::Normal;
+        std::vector<float> rgba(pixelCount * 4);
+        glBindTexture(GL_TEXTURE_2D, m_FrameBuffer.getGBufferTexture(type));
+        glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_FLOAT, rgba.data());
+        glBindTexture(GL_TEXTURE_2D, 0);
+
+        pixels.resize(pixelCount * kChannels);
+        for (size_t i = 0; i < pixelCount; i++) {
+            float r = rgba[i * 4 + 0], g = rgba[i * 4 + 1], b = rgba[i * 4 + 2];
+            if (target == "albedo") {
+                // Linear colour - gamma-encode for a natural-looking preview, matching
+                // how the real lit output eventually gets encoded too (hdr_tonemap.frag).
+                r = std::pow(std::clamp(r, 0.0f, 1.0f), 1.0f / 2.2f);
+                g = std::pow(std::clamp(g, 0.0f, 1.0f), 1.0f / 2.2f);
+                b = std::pow(std::clamp(b, 0.0f, 1.0f), 1.0f / 2.2f);
+            }
+            else {
+                // World-space normal in [-1,1] per channel - remap to [0,1] for display,
+                // the standard normal-map-visualization convention.
+                r = r * 0.5f + 0.5f;
+                g = g * 0.5f + 0.5f;
+                b = b * 0.5f + 0.5f;
+            }
+            pixels[i * 3 + 0] = static_cast<unsigned char>(std::clamp(r, 0.0f, 1.0f) * 255.0f);
+            pixels[i * 3 + 1] = static_cast<unsigned char>(std::clamp(g, 0.0f, 1.0f) * 255.0f);
+            pixels[i * 3 + 2] = static_cast<unsigned char>(std::clamp(b, 0.0f, 1.0f) * 255.0f);
+        }
+    }
+    else {
+        return false; // unrecognised target
+    }
 
     // OpenGL's row 0 is the bottom of the image; PNG expects row 0 at the top -
     // stb_image_write's own flip flag handles this (this vcpkg build doesn't expose

--- a/src/Graphics/Renderers/GL_Deferred_Renderer.h
+++ b/src/Graphics/Renderers/GL_Deferred_Renderer.h
@@ -42,7 +42,7 @@ public:
     float getExposure() const { return m_Exposure; }
     void setAmbientColour(const glm::vec3& colour) { m_AmbientColour = colour; }
     glm::vec3 getAmbientColour() const { return m_AmbientColour; }
-    virtual bool captureFrame(std::vector<unsigned char>& outPNGBytes) override;
+    virtual bool captureFrame(const std::string& target, std::vector<unsigned char>& outPNGBytes) override;
 
 private:
     void geometryPass(EC_GameScene& scene);

--- a/src/Graphics/Renderers/Renderer.h
+++ b/src/Graphics/Renderers/Renderer.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <memory>
+#include <string>
 #include <vector>
 #include "Graphics/Renderers/RenderConfig.h"
 class Window;
@@ -18,10 +19,13 @@ public:
     // shadow map exactly once. Called after a scene finishes loading; default no-op for any
     // Renderer implementation that doesn't support shadow baking.
     virtual void bakeStaticShadows(EC_GameScene& scene) {}
-    // Encodes the most recently rendered frame as a PNG (see EC_DebugHTTPServer's GET
-    // /screenshot) - default no-op/unsupported, matching bakeStaticShadows' convention,
-    // since this is a GL_Deferred_Renderer-specific capability. Must be called from the
-    // GL/main thread - this does real glReadPixels work, not just data access.
-    virtual bool captureFrame(std::vector<unsigned char>& outPNGBytes) { return false; }
+    // Encodes the most recently rendered frame (or, for a non-empty `target`, a single
+    // G-buffer attachment - "albedo"/"normal"/"depth") as a PNG (see EC_DebugHTTPServer's
+    // GET /screenshot) - default no-op/unsupported, matching bakeStaticShadows'
+    // convention, since this is a GL_Deferred_Renderer-specific capability. Must be
+    // called from the GL/main thread - this does real glReadPixels/glGetTexImage work,
+    // not just data access. An empty/unrecognised target falls back to the final
+    // composited frame.
+    virtual bool captureFrame(const std::string& target, std::vector<unsigned char>& outPNGBytes) { return false; }
     virtual ~Renderer();
 };

--- a/src/SceneManager/EC_SceneManager.cpp
+++ b/src/SceneManager/EC_SceneManager.cpp
@@ -220,10 +220,10 @@ bool EC_SceneManager::isSceneActive(const std::string& alias) const
     return it->second == m_ActiveScene;
 }
 
-bool EC_SceneManager::captureFrame(std::vector<unsigned char>& outPNGBytes)
+bool EC_SceneManager::captureFrame(const std::string& target, std::vector<unsigned char>& outPNGBytes)
 {
     if (!m_Renderer) return false;
-    return m_Renderer->captureFrame(outPNGBytes);
+    return m_Renderer->captureFrame(target, outPNGBytes);
 }
 
 void EC_SceneManager::activateSceneByIndex(size_t index)

--- a/src/SceneManager/EC_SceneManager.h
+++ b/src/SceneManager/EC_SceneManager.h
@@ -45,7 +45,7 @@ public:
     bool isSceneActive(const std::string& alias) const;
     // Forwards to the active Renderer - see Renderer::captureFrame's own comment. Must be
     // called from the GL/main thread.
-    bool captureFrame(std::vector<unsigned char>& outPNGBytes);
+    bool captureFrame(const std::string& target, std::vector<unsigned char>& outPNGBytes);
 
     void receive(ECXCommand& command) override;
 


### PR DESCRIPTION
Extends the existing screenshot capture plumbing (proven working for the final composited frame) to individual G-buffer attachments - albedo, normal, depth - exactly the set named in the issue. Reuses the same cross-thread rendezvous, just carries a target string alongside the request now instead of always capturing the composited frame.

Each target needs its own visualization rule, since none of these are display-ready data:
- albedo: linear colour, gamma-encoded for a natural-looking preview (matching how the real lit output eventually gets encoded too, in hdr_tonemap.frag) - read via glGetTexImage on the G-buffer's Albedo attachment (GL_RGBA32F).
- normal: world-space [-1,1] per channel, remapped to [0,1] - the standard normal-map-visualization convention.
- depth: GL_DEPTH_COMPONENT32, already in [0,1] but non-linear NDC depth (the classic 1/z falloff) - displayed as-is per the standard quick depth-debug convention, not linearized.

Verified live this session: fetched all three targets plus the existing final-frame capture from a running instance and confirmed each looks exactly as expected, including background pixels correctly reading as black/mid-gray/white for empty G-buffer data (zero albedo, zero normal, cleared far-depth respectively).

FrameBufferSet gains one small accessor (getGBufferTexture(type)) to reach the raw attachment textures from GL_Deferred_Renderer - the depth accessor already existed.