### PR TITLE
Derive ambient light colour from active scene lights, not a hardcoded constant

### DIFF
--- a/data/scripts/XML/GraphicsSetting.xml
+++ b/data/scripts/XML/GraphicsSetting.xml
@@ -5,4 +5,8 @@
 	<BloomMipLevels>6</BloomMipLevels>
 	<ShadowAtlas size="4096" tileSize="2048"/>
 	<PointShadowPool size="6" faceSize="1024"/>
+	<!-- Scales the intensity-weighted average colour of every active scene light into a
+	     flat ambient fill (issue #96) - not an authored colour itself, since that would go
+	     stale the moment a scene's lights change. -->
+	<AmbientScale>0.15</AmbientScale>
 </GraphicsSettings>

--- a/src/Engine/Subsystems/Scripting/EC_GameAPI.cpp
+++ b/src/Engine/Subsystems/Scripting/EC_GameAPI.cpp
@@ -109,6 +109,14 @@ namespace ScriptAPI
         messenger->publish(cmd);
     }
 
+    void GameAPI::setAmbientScale(float scale) {
+        if (!messenger) return;
+        ECXCommand cmd;
+        cmd.type = ECXCommandType::GraphicsChangeAmbientScale;
+        cmd.args[0] = scale;
+        messenger->publish(cmd);
+    }
+
     void GameAPI::toggleDebug() {
         if (!messenger) return;
         ECXCommand cmd;

--- a/src/Engine/Subsystems/Scripting/EC_GameAPI.h
+++ b/src/Engine/Subsystems/Scripting/EC_GameAPI.h
@@ -29,6 +29,9 @@ namespace ScriptAPI
         void clearParent(unsigned int childID);
 
         void setExposure(float exposure);
+        // Issue #96 - scales the derived (from active scene lights, not authored) ambient
+        // colour. See GL_Deferred_Renderer.h's m_DerivedAmbientColour/m_AmbientScale.
+        void setAmbientScale(float scale);
         void toggleDebug();
         // Issue #108. Requests a window/render resolution change - see Game.h's
         // setResolution() for why this goes through a command rather than a direct call.

--- a/src/Engine/Subsystems/Scripting/EC_LuaScriptingSystem.cpp
+++ b/src/Engine/Subsystems/Scripting/EC_LuaScriptingSystem.cpp
@@ -412,6 +412,7 @@ void EC_LuaScriptSystem::registerAPI() {
         .addFunction("clearParent", &ScriptAPI::GameAPI::clearParent)
         .addFunction("toggleDebug", &ScriptAPI::GameAPI::toggleDebug)
         .addFunction("setExposure", &ScriptAPI::GameAPI::setExposure)
+        .addFunction("setAmbientScale", &ScriptAPI::GameAPI::setAmbientScale)
         .addFunction("setResolution", &ScriptAPI::GameAPI::setResolution)
         .addFunction("toggleFullscreen", &ScriptAPI::GameAPI::toggleFullscreen)
         .addFunction("maximizeWindow", &ScriptAPI::GameAPI::maximizeWindow)

--- a/src/Graphics/Renderers/GL_Deferred_Renderer.cpp
+++ b/src/Graphics/Renderers/GL_Deferred_Renderer.cpp
@@ -130,6 +130,8 @@ void GL_Deferred_Renderer::receive(ECXCommand& command)
 {
     if (command.type == ECXCommandType::GraphicsChangeHDRExposure)
         m_Exposure = std::any_cast<float>(command.args[0]);
+    else if (command.type == ECXCommandType::GraphicsChangeAmbientScale)
+        m_AmbientScale = std::any_cast<float>(command.args[0]);
     else if (command.type == ECXCommandType::GraphicsToggleDebug)
         m_DebugRenderer.toggle();
     else if (command.type == ECXCommandType::GraphicsShowDebugRay)
@@ -161,6 +163,7 @@ void GL_Deferred_Renderer::receive(ECXCommand& command)
 void GL_Deferred_Renderer::init(std::shared_ptr<Window> window, ECXMessenger& messenger, const RenderConfig& config)
 {
     messenger.Subscribe(*this, ECXCommandType::GraphicsChangeHDRExposure);
+    messenger.Subscribe(*this, ECXCommandType::GraphicsChangeAmbientScale);
     messenger.Subscribe(*this, ECXCommandType::GraphicsToggleDebug);
     messenger.Subscribe(*this, ECXCommandType::GraphicsShowDebugRay);
     messenger.Subscribe(*this, ECXCommandType::GraphicsShowDebugCone);
@@ -173,6 +176,7 @@ void GL_Deferred_Renderer::init(std::shared_ptr<Window> window, ECXMessenger& me
     m_Window = window;
     m_RenderConfig = config;
     m_Exposure = config.exposure;
+    m_AmbientScale = config.ambientScale;
     m_DebugRenderer.init(window);
     m_UIRenderer.init(window);
     m_SkyboxRenderer.init(window);
@@ -289,7 +293,7 @@ void GL_Deferred_Renderer::emissivePass()
     m_EmissiveShader.activate();
     m_FrameBuffer.LightingPass(m_EmissiveShader);
     m_EmissiveShader.setUniform("intensity", m_RenderConfig.emissiveIntensity);
-    m_EmissiveShader.setUniform("ambientColour", m_AmbientColour);
+    m_EmissiveShader.setUniform("ambientColour", m_DerivedAmbientColour * m_AmbientScale);
     glEnable(GL_BLEND);
     glBlendFunc(GL_ONE, GL_ONE);
     renderQuad();
@@ -558,6 +562,13 @@ void GL_Deferred_Renderer::updateLights(EC_GameScene& scene)
 
     auto& manager = EC_DOD_EntityManager::getInstance();
 
+    // Intensity-weighted running sum for the derived ambient colour (see
+    // m_DerivedAmbientColour's own comment) - accumulated across every active light below
+    // regardless of type or shadow-casting, since a point/spot-only scene should still get
+    // a sensible ambient derived from what it actually has.
+    glm::vec3 weightedColourSum(0.0f);
+    float totalWeight = 0.0f;
+
     for (EntityID entityID : scene.getLights()) {
         if (!manager.isAlive(entityID)) continue;
         if (!manager.hasComponent<EC_DOD_Light>(entityID)) continue;
@@ -571,6 +582,8 @@ void GL_Deferred_Renderer::updateLights(EC_GameScene& scene)
         }
 
         const auto& light = manager.getComponent<EC_DOD_Light>(entityID);
+        weightedColourSum += light.colour * light.intensity;
+        totalWeight += light.intensity;
 
         if (light.type == EC_DOD_Light::Type::Directional) {
             DirLightData data;
@@ -611,6 +624,11 @@ void GL_Deferred_Renderer::updateLights(EC_GameScene& scene)
             }
         }
     }
+
+    // See m_DerivedAmbientColour's comment: white (a neutral multiplier, leaving
+    // m_AmbientScale as the only effect) when a frame has zero active lights, rather than
+    // dividing by zero.
+    m_DerivedAmbientColour = (totalWeight > 0.0f) ? (weightedColourSum / totalWeight) : glm::vec3(1.0f);
 }
 
 void GL_Deferred_Renderer::bakeStaticShadows(EC_GameScene& scene)

--- a/src/Graphics/Renderers/GL_Deferred_Renderer.h
+++ b/src/Graphics/Renderers/GL_Deferred_Renderer.h
@@ -40,8 +40,10 @@ public:
     virtual void bakeStaticShadows(EC_GameScene& scene) override;
     void setExposure(float exposure) { m_Exposure = exposure; }
     float getExposure() const { return m_Exposure; }
-    void setAmbientColour(const glm::vec3& colour) { m_AmbientColour = colour; }
-    glm::vec3 getAmbientColour() const { return m_AmbientColour; }
+    // Scales the derived ambient colour (see updateLights()'s comment) - not an authored
+    // colour itself, see issue #96.
+    void setAmbientScale(float scale) { m_AmbientScale = scale; }
+    float getAmbientScale() const { return m_AmbientScale; }
     virtual bool captureFrame(const std::string& target, std::vector<unsigned char>& outPNGBytes) override;
 
 private:
@@ -141,18 +143,27 @@ private:
     // Flat ambient term, applied once per frame in emissivePass() (see emissivePass.frag's
     // comment for why it can't live in the per-light shaders) - this renderer has no real
     // indirect/IBL lighting, just enough for AO to have a visible effect.
-    // Raised from the original 0.03 placeholder ("tune once visible in a real scene" - this
-    // was that moment): the voxel terrain's rolling hills, lit by one near-overhead
-    // directional light with CastsShadow=false, exposed how severe that value was. Any
-    // NonShadowDirLightPass.frag fragment past the light's terminator (dot(N,L) <= 0, which
-    // a curved ridge crosses within a few screen pixels) gets exactly this flat ambient
-    // term with NO direct-light contribution at all - at 0.03 that rendered as a hard,
-    // near-black band tracing every ridge crest, easily mistaken for a mesh/normal bug (it
-    // isn't one - both the normal and depth G-buffers were confirmed clean at that exact
-    // location). 0.03 wasn't wrong for a flat-lit test object where every visible face
-    // stays fully on one side of the terminator, but any surface with real curvature will
-    // cross it. Still deliberately subtle/moody, just not jarringly close to zero.
-    glm::vec3 m_AmbientColour = glm::vec3(0.15f);
+    //
+    // The colour itself (m_DerivedAmbientColour) is NOT authored - issue #96 found the
+    // original flat authored constant broke down the moment a scene's lights didn't match
+    // whatever colour was guessed at authoring time (e.g. a scene lit only by red point
+    // lights getting a neutral-grey ambient fill). It's instead the intensity-weighted
+    // average colour of every currently-active light in the scene, recomputed each frame in
+    // updateLights() - so a scene with no directional light still gets a sensible ambient
+    // derived from whatever point/spot lights it actually has, and it never goes stale as
+    // lights are added/removed/recoloured at runtime. Defaults to white (a neutral
+    // multiplier) if a frame has zero active lights, rather than 0/0.
+    //
+    // m_AmbientScale (author-configurable - see RenderConfig::ambientScale) is the actual
+    // tuning knob: how strong that derived fill is. Raised from an original flat-colour
+    // 0.03 placeholder to 0.15 while fixing a terrain shading artifact (PR #92) - at 0.03,
+    // any NonShadowDirLightPass.frag fragment past a light's terminator (dot(N,L) <= 0,
+    // which a curved ridge crosses within a few screen pixels) got only this term with NO
+    // direct-light contribution, rendering as a hard, near-black band that was easily
+    // mistaken for a mesh/normal bug (it wasn't - both the normal and depth G-buffers were
+    // confirmed clean at that exact location).
+    glm::vec3 m_DerivedAmbientColour = glm::vec3(1.0f);
+    float m_AmbientScale = 0.15f;
     Shader m_BloomDownsampleShader;
     Shader m_BloomUpsampleShader;
     Shader m_PointShadowDepthShader;

--- a/src/Graphics/Renderers/RenderConfig.h
+++ b/src/Graphics/Renderers/RenderConfig.h
@@ -13,4 +13,11 @@ struct RenderConfig
     // deliberately less than the camera's own draw distance, to keep shadow-map texel
     // density reasonable (see GL_Deferred_Renderer::shadowDirPass).
     float dirShadowDistance = 50.0f;
+    // Multiplies the intensity-weighted average colour of every active light in the scene
+    // (see GL_Deferred_Renderer::updateLights) to get the flat ambient fill term applied in
+    // emissivePass() - NOT an authored colour itself (issue #96: a scene with only, say,
+    // red point lights and no directional light should get a reddish ambient, not
+    // whatever fixed colour an author guessed at authoring time). This is just how strong
+    // that derived fill is.
+    float ambientScale = 0.15f;
 };

--- a/src/Messaging/ECXCommandType.h
+++ b/src/Messaging/ECXCommandType.h
@@ -24,6 +24,7 @@ enum class ECXCommandType
 	GameSaveWorld,
 	GameLoadWorld,
 	GraphicsChangeHDRExposure,
+	GraphicsChangeAmbientScale,
 	GraphicsToggleDebug,
 	GraphicsShowDebugRay,
 	GraphicsShowDebugCone,

--- a/src/xml/XML.h
+++ b/src/xml/XML.h
@@ -392,6 +392,10 @@ namespace XML
 				const char* distance = child->Attribute("distance");
 				if (distance) settings.dirShadowDistance = std::stof(distance);
 			}
+			else if (strcmp(child->Value(), "AmbientScale") == 0 && child->GetText())
+			{
+				settings.ambientScale = std::stof(child->GetText());
+			}
 			child = child->NextSiblingElement();
 		}
 		return true;


### PR DESCRIPTION
## Summary
- Closes #96. Original scope was "make the hardcoded ambient colour author-configurable," but review surfaced a real correctness gap in a flat authored colour: it goes stale the moment a scene's actual lights don't match it, and breaks entirely for scenes without a directional light if scoped to directional-only sources.
- Ambient colour is now derived every frame: an intensity-weighted average of every active light in the scene (any type, shadow-casting or not), computed in the same per-frame pass that already iterates lights for real lighting (`updateLights()`). Falls back to white if a frame has zero active lights.
- The only remaining authored/tunable value is a scale factor (`RenderConfig::ambientScale`, `GraphicsSetting.xml`'s `<AmbientScale>`) controlling how strong that derived fill is - also runtime-settable from Lua via `game:setAmbientScale()`.

## Test plan
- [x] Full engine build clean
- [x] All 1335 unit test assertions pass
- [x] Live-tested: temporarily recoloured the demo's sun red - the previously neutral ambient-only (backlit) terrain picked up the red tint correctly, confirmed visually, then reverted

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)