### PR TITLE
Make directional shadow bias author-configurable

### DIFF
--- a/data/assets/shaders/DirLightShadowPBR.frag
+++ b/data/assets/shaders/DirLightShadowPBR.frag
@@ -42,6 +42,11 @@ uniform vec3 WSCamPos;
 // from - needed to convert a world-space bias into the right NDC offset, since the box's
 // depth range varies with the camera-fit frustum instead of being a fixed constant.
 uniform float ShadowDepthRange;
+// Author-configurable multiplier on the base bias below (issue #97, RenderConfig::
+// dirShadowBiasScale) - the base constants were tuned for one project's default scale
+// (dirShadowDistance=50, shadowAtlasTileSize=1024); a scene at a very different scale needs
+// this scaled to match, see that field's own comment for the texel-density reasoning.
+uniform float BiasScale;
 
 in xferBlock
 {
@@ -164,7 +169,7 @@ float computeOcclusion(vec4 shadowCoords, vec3 normal, vec3 lightDir)
 	// originally tuned against. A real fix (cascaded shadow maps, giving high resolution
 	// near the camera without sacrificing shadow distance) is out of scope for a bias tweak;
 	// this raises the floor enough to clean up self-shadowing at the terrain's actual scale.
-	float worldBias 	= mix(0.4, 0.05, max(dot(normal, lightDir), 0.0));
+	float worldBias 	= mix(0.4, 0.05, max(dot(normal, lightDir), 0.0)) * BiasScale;
 	float ndcBias 		= worldBias * (1.0 / max(ShadowDepthRange, 1.0));
 
 	// Software PCF: average a 3x3 neighbourhood of shadow-map texels instead of relying on

--- a/data/scripts/XML/GraphicsSetting.xml
+++ b/data/scripts/XML/GraphicsSetting.xml
@@ -5,6 +5,12 @@
 	<BloomMipLevels>6</BloomMipLevels>
 	<ShadowAtlas size="4096" tileSize="2048"/>
 	<PointShadowPool size="6" faceSize="1024"/>
+	<!-- distance: how far the directional-shadow frustum reaches along the camera's view.
+	     biasScale (issue #97): scales the read-side shadow bias that avoids self-shadowing
+	     acne - see RenderConfig::dirShadowBiasScale's comment for how to retune it if this
+	     scene's scale (dirShadowDistance vs ShadowAtlas's tileSize) changes a lot from the
+	     defaults these were tuned against. 1.0 = unchanged from the tuned base values. -->
+	<DirShadow distance="50" biasScale="1.0"/>
 	<!-- Scales the intensity-weighted average colour of every active scene light into a
 	     flat ambient fill (issue #96) - not an authored colour itself, since that would go
 	     stale the moment a scene's lights change. -->

--- a/src/Graphics/Renderers/GL_Deferred_Renderer.cpp
+++ b/src/Graphics/Renderers/GL_Deferred_Renderer.cpp
@@ -1120,6 +1120,10 @@ void GL_Deferred_Renderer::shadowLightingPass(EC_GameScene& scene)
             // into the right NDC offset - this varies with the camera-fit frustum, unlike the
             // old fixed ~30-unit box, so it can't be a shader constant.
             m_ShadowDirLightShader.setUniform("ShadowDepthRange", activeBounds.maxZ - activeBounds.minZ);
+            // Author-configurable (RenderConfig::dirShadowBiasScale, GraphicsSetting.xml's
+            // <DirShadow biasScale="...">) - issue #97. See that field's own comment for why
+            // a fixed shader constant doesn't generalize across scenes at different scales.
+            m_ShadowDirLightShader.setUniform("BiasScale", m_RenderConfig.dirShadowBiasScale);
             m_ShadowDirLightShader.bindTexture("shadowMap", 5, m_ShadowAtlas.getDepthTexture());
             renderQuad();
             glDisable(GL_BLEND);

--- a/src/Graphics/Renderers/RenderConfig.h
+++ b/src/Graphics/Renderers/RenderConfig.h
@@ -13,6 +13,16 @@ struct RenderConfig
     // deliberately less than the camera's own draw distance, to keep shadow-map texel
     // density reasonable (see GL_Deferred_Renderer::shadowDirPass).
     float dirShadowDistance = 50.0f;
+    // Multiplies DirLightShadowPBR.frag's read-side shadow bias (issue #97). The bias needed
+    // to avoid self-shadowing acne scales with shadow-map texel density - roughly
+    // (shadow box world-space width) / (atlas tile size in texels): a bigger box or a
+    // smaller tile both mean each texel covers more world space, needing more bias to clear
+    // the resulting depth-quantization error. The shader's own base bias constants were
+    // tuned for this project's default scale (dirShadowDistance=50, shadowAtlasTileSize=
+    // 1024) - a scene at a very different scale (much larger dirShadowDistance, or a
+    // smaller atlas tile) should scale this up; a smaller/denser scene can likely scale it
+    // down. 1.0 leaves the tuned base values unchanged.
+    float dirShadowBiasScale = 1.0f;
     // Multiplies the intensity-weighted average colour of every active light in the scene
     // (see GL_Deferred_Renderer::updateLights) to get the flat ambient fill term applied in
     // emissivePass() - NOT an authored colour itself (issue #96: a scene with only, say,

--- a/src/xml/XML.h
+++ b/src/xml/XML.h
@@ -391,6 +391,8 @@ namespace XML
 			{
 				const char* distance = child->Attribute("distance");
 				if (distance) settings.dirShadowDistance = std::stof(distance);
+				const char* biasScale = child->Attribute("biasScale");
+				if (biasScale) settings.dirShadowBiasScale = std::stof(biasScale);
 			}
 			else if (strcmp(child->Value(), "AmbientScale") == 0 && child->GetText())
 			{


### PR DESCRIPTION
## Summary
- Closes #97. `DirLightShadowPBR.frag`'s read-side shadow bias was a hardcoded shader constant tuned for this project's default scale (`dirShadowDistance=50`, `shadowAtlasTileSize=1024`) - a scene at a meaningfully different scale would need different values, previously only changeable by editing the shader and recompiling.
- New `RenderConfig::dirShadowBiasScale` (default `1.0`, unchanged behaviour), author-configurable via `GraphicsSetting.xml`'s existing `<DirShadow>` tag (`biasScale` attribute), threaded through as a `BiasScale` uniform.
- Documented the texel-density-vs-bias relationship in `RenderConfig::dirShadowBiasScale`'s own comment, per the ticket's ask, so an author has a starting point instead of trial-and-error.

## Test plan
- [x] Full engine build clean
- [x] All 1335 unit test assertions pass
- [x] Live-tested at default (`1.0`) - clean, matches pre-existing tuned behaviour, no acne
- [x] Live-tested at an extreme scale-down (`0.05`) - reintroduced subtle faceted self-shadowing artifacts not present at `1.0`, confirming the uniform has real effect - then reverted

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)