### PR TITLE
Read collider dimensions from the entity instead of hardcoding them in Lua

### DIFF
--- a/data/scripts/LUA/ArcadeGravity.lua
+++ b/data/scripts/LUA/ArcadeGravity.lua
@@ -43,15 +43,6 @@ local GROUND_SKIN = 0.02 -- small persistent overlap kept after snapping, so the
 local MIN_STANDING_NORMAL_Y = 0.3 -- how "upward-facing" a contact normal must be to count
                                     -- as ground to stand on, vs. a wall/steep slope
 
--- Capsule dimensions are fixed module-level constants, not read per-entity: there's no
--- Lua binding today to read a collider's own radius/height back off an entity (only to
--- author one via XML). Must match whatever <Collider><Radius>/<Height> every entity using
--- this script was actually given - currently just VoxelChunkDemo.xml's camera capsule
--- (0.5 / 2.0). A future getColliderRadius()/getColliderHeight() binding would let this
--- read real per-entity values instead.
-local CAPSULE_RADIUS = 0.5
-local CAPSULE_HALF_HEIGHT = 1.0
-
 local LOG_INTERVAL = 0.5 -- throttled so this doesn't spam the log at 60+ lines/sec
 
 -- Hysteresis on LEAVING grounded state only (entering is instant - see update() below).
@@ -74,10 +65,23 @@ local UNGROUNDED_FRAMES_TO_RELEASE = 4
 local debugTextID = nil
 local debugTextReady = false
 
-local function getState(entityId)
+-- Capsule dimensions are read from the entity's own Collider (issue #98 - previously fixed
+-- module-level constants that had to be hand-kept in sync with whatever <Collider>
+-- <Radius>/<Height> an entity using this script was actually given, silently wrong the
+-- moment they drifted apart). Read once per entity, at first update(), and cached in that
+-- entity's own state table - the collider is authored once in XML and not expected to
+-- change at runtime, so there's no need to re-query every frame. getColliderHeight()
+-- returns the full capsule height (cylinder-axis segment length, not including the
+-- hemispherical caps - see EC_DOD_EntityFactory::parseCollider), so half of it is what the
+-- capsuleQuery segment below actually wants.
+local function getState(entityId, entity)
     local s = states[entityId]
     if not s then
-        s = { fallSpeed = 0.0, grounded = false, ungroundedStreak = 0, logTimer = 0.0 }
+        s = {
+            fallSpeed = 0.0, grounded = false, ungroundedStreak = 0, logTimer = 0.0,
+            capsuleRadius = entity:getColliderRadius(),
+            capsuleHalfHeight = entity:getColliderHeight() * 0.5,
+        }
         states[entityId] = s
     end
     return s
@@ -85,7 +89,7 @@ end
 
 function update(entity, deltaTime)
     local entityId = entity:getID()
-    local state = getState(entityId)
+    local state = getState(entityId, entity)
     local pos = entity:getPosition()
     local wasGrounded = state.grounded
 
@@ -98,9 +102,9 @@ function update(entity, deltaTime)
     local newY = pos.y - state.fallSpeed * deltaTime
 
     local hits = game:capsuleQuery(
-        pos.x, newY - CAPSULE_HALF_HEIGHT, pos.z,
-        pos.x, newY + CAPSULE_HALF_HEIGHT, pos.z,
-        CAPSULE_RADIUS, true, entityId)
+        pos.x, newY - state.capsuleHalfHeight, pos.z,
+        pos.x, newY + state.capsuleHalfHeight, pos.z,
+        state.capsuleRadius, true, entityId)
 
     if hits > 0 then
         local normal = game:getCapsuleHitNormal(0)

--- a/src/Engine/Subsystems/Scripting/EC_EntityAPI.cpp
+++ b/src/Engine/Subsystems/Scripting/EC_EntityAPI.cpp
@@ -187,6 +187,20 @@ namespace ScriptAPI
         mgr.getComponent<EC_DOD_GraphicsData>(entityID).colour = glm::vec4(r, g, b, a);
     }
 
+    float EntityAPI::getColliderRadius() {
+        auto& mgr = EC_DOD_EntityManager::getInstance();
+        if (!mgr.isAlive(entityID)) return 0.0f;
+        if (!mgr.hasComponent<EC_DOD_Collider>(entityID)) return 0.0f;
+        return mgr.getComponent<EC_DOD_Collider>(entityID).radius;
+    }
+
+    float EntityAPI::getColliderHeight() {
+        auto& mgr = EC_DOD_EntityManager::getInstance();
+        if (!mgr.isAlive(entityID)) return 0.0f;
+        if (!mgr.hasComponent<EC_DOD_Collider>(entityID)) return 0.0f;
+        return mgr.getComponent<EC_DOD_Collider>(entityID).height;
+    }
+
     // Hierarchy queries
     bool EntityAPI::hasParent() {
         auto& mgr = EC_DOD_EntityManager::getInstance();

--- a/src/Engine/Subsystems/Scripting/EC_EntityAPI.h
+++ b/src/Engine/Subsystems/Scripting/EC_EntityAPI.h
@@ -43,6 +43,13 @@ namespace ScriptAPI
         glm::vec4 getColour();
         void setColour(float r, float g, float b, float a = 1.0f);
 
+        // Issue #98 - lets a reusable script (e.g. ArcadeGravity.lua) read an entity's own
+        // authored collider dimensions back, instead of hand-keeping a separate hardcoded
+        // copy in sync with whatever <Collider><Radius>/<Height> the entity was actually
+        // given. 0 for an entity with no Collider component at all.
+        float getColliderRadius();
+        float getColliderHeight();
+
         // Hierarchy queries
         bool hasParent();
         unsigned int getParentID();

--- a/src/Engine/Subsystems/Scripting/EC_LuaScriptingSystem.cpp
+++ b/src/Engine/Subsystems/Scripting/EC_LuaScriptingSystem.cpp
@@ -360,6 +360,8 @@ void EC_LuaScriptSystem::registerAPI() {
         .addFunction("getString", &ScriptAPI::EntityAPI::getString)
         .addFunction("getColour", &ScriptAPI::EntityAPI::getColour)
         .addFunction("setColour", &ScriptAPI::EntityAPI::setColour)
+        .addFunction("getColliderRadius", &ScriptAPI::EntityAPI::getColliderRadius)
+        .addFunction("getColliderHeight", &ScriptAPI::EntityAPI::getColliderHeight)
         .addFunction("hasParent", &ScriptAPI::EntityAPI::hasParent)
         .addFunction("getParentID", &ScriptAPI::EntityAPI::getParentID)
         .addFunction("getDepth", &ScriptAPI::EntityAPI::getDepth)


### PR DESCRIPTION
## Summary
- Closes #98. `ArcadeGravity.lua`'s `CAPSULE_RADIUS`/`CAPSULE_HALF_HEIGHT` were fixed module-level constants that had to be hand-kept in sync with whatever `<Collider><Radius>/<Height>` an entity using this script was actually given in XML - there was no Lua binding to read that back, only to author it.
- Added `EntityAPI::getColliderRadius()`/`getColliderHeight()` (mirrors the existing `getPosition()`/`getColour()` pattern), exposed to Lua.
- `ArcadeGravity.lua` now reads these once per entity at first `update()` and caches them in that entity's own state table.

## Test plan
- [x] Full engine build clean
- [x] All 1335 unit test assertions pass
- [x] Live-tested at the existing collider size - bit-identical debug readout to the pre-change baseline
- [x] Temporarily changed the demo's collider to 1.5/6.0 and confirmed the capsule settled at a meaningfully different height purely from the XML edit (13.246 vs. 10.056), proving the script genuinely reads the collider at runtime - then reverted

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)