### PR TITLE
Make voxel terrain opt-in and author-configurable

### DIFF
--- a/data/scripts/XML/EngineConfig.xml
+++ b/data/scripts/XML/EngineConfig.xml
@@ -56,4 +56,11 @@
 	     explicitly enabled per-machine. -->
 	<DebugHTTP enabled="false" port="8089"/>
 
+	<!-- Issue #99 - voxel terrain is opt-in (a game with no use for it gets zero side
+	     effects: no worker thread, no chunk entities, no generation work). Enabled here
+	     since this repo's own demo scene (voxelchunkdemo) uses it - `script` only says
+	     which generation script to run; chunk material/tint/grid size are configured by
+	     that script itself (see TerrainGeneration.lua and VoxelTerrainConfig). -->
+	<VoxelTerrain enabled="true" script="data/scripts/LUA/TerrainGeneration.lua"/>
+
 </EngineSettings>

--- a/src/Engine/EC_Engine.cpp
+++ b/src/Engine/EC_Engine.cpp
@@ -127,6 +127,12 @@ std::shared_ptr<EC_VolumeNode> EC_Engine::getVolumeRoot() const
 	return scripting ? scripting->getVolumeRoot() : nullptr;
 }
 
+ScriptAPI::VoxelTerrainConfig EC_Engine::getVoxelTerrainConfig() const
+{
+	auto* scripting = static_cast<EC_LuaScriptSystem*>(m_Systems[(size_t)EC_SystemType::Scripting].get());
+	return scripting ? scripting->getVoxelTerrainConfig() : ScriptAPI::VoxelTerrainConfig{};
+}
+
 EC_Engine::~EC_Engine()
 {
 }

--- a/src/Engine/EC_Engine.h
+++ b/src/Engine/EC_Engine.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <vector>
 #include "Messaging/ECXMessenger.h"
+#include "Engine/Subsystems/Scripting/EC_VolumeAPI.h"
 
 class GameEntity;
 class EC_Game;
@@ -36,6 +37,7 @@ public:
 	// per-frame/per-event handler scripts.
 	bool runLuaScriptOnce(const std::string& filename);
 	std::shared_ptr<EC_VolumeNode> getVolumeRoot() const;
+	ScriptAPI::VoxelTerrainConfig getVoxelTerrainConfig() const;
 	~EC_Engine();
 private:
 	std::vector<std::shared_ptr<EC_System>> m_Systems;

--- a/src/Engine/Subsystems/Scripting/EC_LuaScriptingSystem.cpp
+++ b/src/Engine/Subsystems/Scripting/EC_LuaScriptingSystem.cpp
@@ -482,6 +482,9 @@ void EC_LuaScriptSystem::registerAPI() {
         .addFunction("smoothSubtract", &ScriptAPI::VolumeAPI::smoothSubtract)
         .addFunction("translate", &ScriptAPI::VolumeAPI::translate)
         .addFunction("setRoot", &ScriptAPI::VolumeAPI::setRoot)
+        .addFunction("setChunkMaterial", &ScriptAPI::VolumeAPI::setChunkMaterial)
+        .addFunction("setChunkColour", &ScriptAPI::VolumeAPI::setChunkColour)
+        .addFunction("setGridRadius", &ScriptAPI::VolumeAPI::setGridRadius)
         .endClass();
 
     auto pushResult = luabridge::push(m_luaState, m_game);
@@ -528,4 +531,8 @@ bool EC_LuaScriptSystem::runScriptOnce(const std::string& filename) {
 
 std::shared_ptr<EC_VolumeNode> EC_LuaScriptSystem::getVolumeRoot() const {
     return m_volumeAPI ? m_volumeAPI->getRoot() : nullptr;
+}
+
+ScriptAPI::VoxelTerrainConfig EC_LuaScriptSystem::getVoxelTerrainConfig() const {
+    return m_volumeAPI ? m_volumeAPI->getConfig() : ScriptAPI::VoxelTerrainConfig{};
 }

--- a/src/Engine/Subsystems/Scripting/EC_LuaScriptingSystem.h
+++ b/src/Engine/Subsystems/Scripting/EC_LuaScriptingSystem.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include "Engine/Subsystems/EC_System.h"
 #include "Messaging/IEventListener.h"
+#include "Engine/Subsystems/Scripting/EC_VolumeAPI.h"
 
 // Forward declarations only - the Lua/luabridge headers and the ScriptAPI
 // wrapper classes are only needed by the .cpp's method bodies, not by this
@@ -37,6 +38,10 @@ public:
     // Valid only after runScriptOnce() on a script that called volume.setRoot(...) - null
     // otherwise. See EC_VolumeAPI::setRoot/getRoot.
     std::shared_ptr<EC_VolumeNode> getVolumeRoot() const;
+    // Bundles everything else EC_VoxelChunkSystem needs besides the shape itself (issue
+    // #99) - see VoxelTerrainConfig's own comment. Returns the struct's defaults if no
+    // script has run yet.
+    ScriptAPI::VoxelTerrainConfig getVoxelTerrainConfig() const;
 
 private:
     std::atomic<bool> m_shuttingDown{ false };

--- a/src/Engine/Subsystems/Scripting/EC_VolumeAPI.cpp
+++ b/src/Engine/Subsystems/Scripting/EC_VolumeAPI.cpp
@@ -27,4 +27,17 @@ namespace ScriptAPI
     VolumeHandle VolumeAPI::translate(VolumeHandle a, const glm::vec3& offset) { return { EC_Volume::translate(a.node, offset) }; }
 
     void VolumeAPI::setRoot(VolumeHandle root) { m_Root = root.node; }
+
+    void VolumeAPI::setChunkMaterial(const std::string& vertShader, const std::string& fragShader) {
+        m_Config.chunkVertShader = vertShader;
+        m_Config.chunkFragShader = fragShader;
+    }
+
+    void VolumeAPI::setChunkColour(float r, float g, float b, float a) {
+        m_Config.chunkColour = glm::vec4(r, g, b, a);
+    }
+
+    void VolumeAPI::setGridRadius(int radius) {
+        m_Config.gridRadius = radius;
+    }
 }

--- a/src/Engine/Subsystems/Scripting/EC_VolumeAPI.h
+++ b/src/Engine/Subsystems/Scripting/EC_VolumeAPI.h
@@ -1,9 +1,24 @@
 #pragma once
 #include "Procedural/EC_VolumeNode.h"
 #include <glm/glm.hpp>
+#include <string>
 
 namespace ScriptAPI
 {
+    // Everything EC_VoxelChunkSystem needs besides the shape itself (see VolumeAPI::getRoot)
+    // to spawn/mesh/render voxel terrain - previously hardcoded C++ constants
+    // (kGridRadius, the chunk shader paths, the tint colour) in EC_VoxelChunkSystem.cpp
+    // (issue #99). Defaults here match that old hardcoded behaviour exactly, so a
+    // generation script that doesn't call setChunkMaterial()/setChunkColour()/
+    // setGridRadius() gets today's look unchanged.
+    struct VoxelTerrainConfig
+    {
+        std::string chunkVertShader = "data/assets/shaders/basic.vert";
+        std::string chunkFragShader = "data/assets/shaders/PBR.frag";
+        glm::vec4 chunkColour{ 0.5f, 0.45f, 0.35f, 1.0f };
+        int gridRadius = 1;
+    };
+
     // Lua-visible copyable wrapper around a shared_ptr<EC_VolumeNode> - registered as a
     // LuaBridge value type exactly like glm::vec3/vec4 (see EC_LuaScriptingSystem's
     // registerAPI()), so every volume.* call below can take/return it and Lua composition
@@ -43,7 +58,17 @@ namespace ScriptAPI
         void setRoot(VolumeHandle root);
         EC_VolumeNodePtr getRoot() const { return m_Root; }
 
+        // Issue #99 - author-facing config a generation script can set alongside setRoot(),
+        // instead of the engine hardcoding a chunk material/tint/grid size for every game.
+        // All optional; see VoxelTerrainConfig's own comment for the defaults used if a
+        // script doesn't call these.
+        void setChunkMaterial(const std::string& vertShader, const std::string& fragShader);
+        void setChunkColour(float r, float g, float b, float a);
+        void setGridRadius(int radius);
+        const VoxelTerrainConfig& getConfig() const { return m_Config; }
+
     private:
         EC_VolumeNodePtr m_Root;
+        VoxelTerrainConfig m_Config;
     };
 }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -45,7 +45,17 @@ Game_Error EC_Game::init(const std::string& configurationFilename)
 
     m_Timer = std::make_unique<Timer>();
     m_threadmanager.init(8);
-    m_VoxelChunkSystem.init(m_Messenger, *this);
+
+    // Issue #99 - voxel terrain is opt-in: a game that doesn't enable it gets zero side
+    // effects (no worker thread, no chunk entities, no generation work), matching
+    // DebugHTTPSettings' own "off unless explicitly requested" pattern just above.
+    XML::VoxelTerrainSettings voxelTerrainSettings;
+    XML::loadVoxelTerrainSettings(m_SceneManager.getEngineConfigPath(), voxelTerrainSettings);
+    if (voxelTerrainSettings.enabled)
+    {
+        m_VoxelChunkSystem.setGenerationScriptPath(voxelTerrainSettings.script);
+        m_VoxelChunkSystem.init(m_Messenger, *this);
+    }
 
     XML::DebugHTTPSettings debugHttpSettings;
     XML::loadDebugHTTPSettings(m_SceneManager.getEngineConfigPath(), debugHttpSettings);
@@ -331,6 +341,11 @@ bool EC_Game::runLuaScriptOnce(const std::string& filename)
 std::shared_ptr<EC_VolumeNode> EC_Game::getVolumeRoot() const
 {
     return m_SceneManager.getVolumeRoot();
+}
+
+ScriptAPI::VoxelTerrainConfig EC_Game::getVoxelTerrainConfig() const
+{
+    return m_SceneManager.getVoxelTerrainConfig();
 }
 
 void EC_Game::regenerateTerrain()

--- a/src/Game.h
+++ b/src/Game.h
@@ -89,6 +89,7 @@ public:
     // game's terrain-generation script once and retrieve the shape it authored.
     bool runLuaScriptOnce(const std::string& filename);
     std::shared_ptr<EC_VolumeNode> getVolumeRoot() const;
+    ScriptAPI::VoxelTerrainConfig getVoxelTerrainConfig() const;
     // Re-runs the terrain generation script and re-schedules every existing chunk against
     // the new shape, live - see EC_VoxelChunkSystem::regenerate(). Must be called from the
     // main thread (same requirement as everything else that touches m_VoxelChunkSystem).

--- a/src/SceneManager/EC_SceneManager.cpp
+++ b/src/SceneManager/EC_SceneManager.cpp
@@ -244,6 +244,11 @@ std::shared_ptr<EC_VolumeNode> EC_SceneManager::getVolumeRoot() const
     return m_Engine.getVolumeRoot();
 }
 
+ScriptAPI::VoxelTerrainConfig EC_SceneManager::getVoxelTerrainConfig() const
+{
+    return m_Engine.getVoxelTerrainConfig();
+}
+
 void EC_SceneManager::activateSceneByIndex(size_t index)
 {
     size_t previous = m_ActiveScene;

--- a/src/SceneManager/EC_SceneManager.h
+++ b/src/SceneManager/EC_SceneManager.h
@@ -56,6 +56,7 @@ public:
     // getVolumeRoot and EC_Engine's own forwarding methods.
     bool runLuaScriptOnce(const std::string& filename);
     std::shared_ptr<EC_VolumeNode> getVolumeRoot() const;
+    ScriptAPI::VoxelTerrainConfig getVoxelTerrainConfig() const;
 
     void receive(ECXCommand& command) override;
 

--- a/src/Terrain/EC_VoxelChunkSystem.cpp
+++ b/src/Terrain/EC_VoxelChunkSystem.cpp
@@ -8,19 +8,13 @@
 #include "Graphics/Models/ObjModel.h"
 #include "Graphics/Shaders/Shader.h"
 #include "Logging/ECX_Logging.h"
+#include "Engine/Subsystems/Scripting/EC_VolumeAPI.h"
 
 namespace {
-    // Small fixed grid, one Y layer - enough to prove multiple chunks stitch together
-    // seamlessly without a distance-based streaming trigger yet (deferred to a later
-    // slice, along with LOD).
-    constexpr int kGridRadius = 1; // chunks from -1..1 in X and Z => 3x3
-
     // Chunks finishing several at once (e.g. right after startup) would spike a frame if
     // all uploaded in one go - matches the throttling rationale behind
     // EC_DOD_EntityFactory::finalizePendingGraphics(maxPerCall).
     constexpr int kMaxUploadsPerFrame = 2;
-
-    constexpr const char* kTerrainScript = "data/scripts/LUA/TerrainGeneration.lua";
 }
 
 EC_VoxelChunkSystem::EC_VoxelChunkSystem() {
@@ -35,23 +29,31 @@ void EC_VoxelChunkSystem::shutdown() {
 }
 
 void EC_VoxelChunkSystem::init(ECXMessenger& messenger, EC_Game& game) {
+    m_Worker = std::make_shared<EC_VoxelChunkWorker>();
+    // Run the generation script first (issue #99): besides building the density shape
+    // (setRoot), it can also configure the chunk material/tint/grid size below via
+    // volume.setChunkMaterial()/setChunkColour()/setGridRadius() - see VoxelTerrainConfig's
+    // own comment for the defaults used if it doesn't.
+    loadVolumeScript(game);
+    ScriptAPI::VoxelTerrainConfig config = game.getVoxelTerrainConfig();
+
     m_ChunkShader = std::make_shared<Shader>();
-    if (!m_ChunkShader->loadShader("data/assets/shaders/basic.vert", "data/assets/shaders/PBR.frag")) {
+    if (!m_ChunkShader->loadShader(config.chunkVertShader, config.chunkFragShader)) {
         LOGGING::ECX_Logger::GetInstance()->LogMessage(
             "EC_VoxelChunkSystem: failed to load chunk shader", LOGGING::LogLevel::CRITICAL);
         return;
     }
-
-    m_Worker = std::make_shared<EC_VoxelChunkWorker>();
-    loadVolumeScript(game);
 
     m_ThreadManager.addTask(m_Worker);
     m_ThreadManager.executeTasks();
 
     auto& manager = EC_DOD_EntityManager::getInstance();
 
-    for (int x = -kGridRadius; x <= kGridRadius; x++) {
-        for (int z = -kGridRadius; z <= kGridRadius; z++) {
+    // One Y layer, radius from config (was a fixed 3x3 - kGridRadius=1 - just enough to
+    // prove multiple chunks stitch together seamlessly; distance-based streaming and LOD
+    // are still a later slice regardless of grid size).
+    for (int x = -config.gridRadius; x <= config.gridRadius; x++) {
+        for (int z = -config.gridRadius; z <= config.gridRadius; z++) {
             glm::ivec3 coord(x, 0, z);
 
             EntityID entity = manager.createEntity();
@@ -65,7 +67,7 @@ void EC_VoxelChunkSystem::init(ECXMessenger& messenger, EC_Game& game) {
 
             EC_DOD_GraphicsData gfx;
             gfx.shader = m_ChunkShader;
-            gfx.colour = glm::vec4(0.5f, 0.45f, 0.35f, 1.0f);
+            gfx.colour = config.chunkColour;
             manager.addComponent(entity, gfx);
 
             EC_DOD_VoxelChunk chunk;
@@ -99,9 +101,9 @@ void EC_VoxelChunkSystem::loadVolumeScript(EC_Game& game) {
     // EC_LuaScriptSystem's shared lua_State always executes on - so this is safe even
     // though EC_VoxelChunkWorker::execute() runs on a background thread afterward; the tree
     // itself is pure/stateless once built (see EC_VolumeNode's own comment).
-    if (!game.runLuaScriptOnce(kTerrainScript)) {
+    if (!game.runLuaScriptOnce(m_GenerationScriptPath)) {
         LOGGING::ECX_Logger::GetInstance()->LogMessage(
-            "EC_VoxelChunkSystem: failed to run " + std::string(kTerrainScript) + " - chunks will generate as empty space",
+            "EC_VoxelChunkSystem: failed to run " + m_GenerationScriptPath + " - chunks will generate as empty space",
             LOGGING::LogLevel::SEVERE);
     }
     m_Worker->setVolumeRoot(game.getVolumeRoot());
@@ -123,7 +125,7 @@ void EC_VoxelChunkSystem::regenerate(EC_Game& game) {
     }
 
     LOGGING::ECX_Logger::GetInstance()->LogMessage(
-        "EC_VoxelChunkSystem: regenerating " + std::to_string(m_ChunkEntities.size()) + " chunks from " + kTerrainScript,
+        "EC_VoxelChunkSystem: regenerating " + std::to_string(m_ChunkEntities.size()) + " chunks from " + m_GenerationScriptPath,
         LOGGING::LogLevel::INFORMATION);
 }
 

--- a/src/Terrain/EC_VoxelChunkSystem.h
+++ b/src/Terrain/EC_VoxelChunkSystem.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <atomic>
 #include <memory>
+#include <string>
 #include <vector>
 #include "Engine/Subsystems/EC_System.h"
 #include "TaskManager/EC_ThreadManager.h"
@@ -27,6 +28,13 @@ public:
 
     virtual void init(ECXMessenger& messenger, EC_Game& game) override;
     virtual void update(const float& deltaTimeS, EC_Game& game) override;
+
+    // Issue #99 - must be called before init() if the caller wants a different generation
+    // script than the default below. Can't be an init() parameter without changing every
+    // EC_System's shared virtual signature, so this is a setter instead - EC_Game::init()
+    // calls it (from EngineConfig.xml's <VoxelTerrain script="...">) only when voxel terrain
+    // is actually enabled for this game.
+    void setGenerationScriptPath(const std::string& path) { m_GenerationScriptPath = path; }
 
     // Must be called before EC_ThreadManager::stop() joins the shared pool - the worker's
     // execute() loop only exits once this notifies it, otherwise the join deadlocks on a
@@ -55,6 +63,7 @@ private:
     void regenerate(EC_Game& game);
 
     std::atomic<bool> m_RegenerateRequested{ false };
+    std::string m_GenerationScriptPath = "data/scripts/LUA/TerrainGeneration.lua";
     EC_ThreadManager m_ThreadManager;
     std::shared_ptr<EC_VoxelChunkWorker> m_Worker;
     std::shared_ptr<Shader> m_ChunkShader;

--- a/src/xml/XML.h
+++ b/src/xml/XML.h
@@ -239,6 +239,47 @@ namespace XML
 		return true;
 	}
 
+	// EngineConfig.xml's <VoxelTerrain enabled="" script=""/> - issue #99: this whole
+	// subsystem (a background worker thread, a grid of chunk entities, generation work)
+	// used to run unconditionally for every game regardless of whether it wanted voxel
+	// terrain at all. Defaults to disabled on any missing file/section/attribute, matching
+	// DebugHTTPSettings' own "never turn on unexpectedly" reasoning - though unlike
+	// DebugHTTP this gates a gameplay-visible feature, not just a dev tool, so an author
+	// must always opt in explicitly. `script` only needs to say WHICH generation script to
+	// run - everything else content-configurable (chunk material, tint, grid size) is set
+	// by that script itself via the volume.* Lua API (see VoxelTerrainConfig), not more XML
+	// attributes here.
+	struct VoxelTerrainSettings
+	{
+		bool enabled = false;
+		std::string script = "data/scripts/LUA/TerrainGeneration.lua";
+	};
+
+	inline bool loadVoxelTerrainSettings(const std::string& file, VoxelTerrainSettings& outSettings)
+	{
+		outSettings = VoxelTerrainSettings{};
+
+		TiXmlDocument doc(file.c_str());
+		if (!doc.LoadFile())
+			return false;
+		auto root = doc.FirstChildElement();
+		if (!root)
+			return false;
+
+		auto voxelTerrain = root->FirstChildElement("VoxelTerrain");
+		if (!voxelTerrain)
+			return true;
+
+		const char* enabledAttr = voxelTerrain->Attribute("enabled");
+		if (enabledAttr)
+			outSettings.enabled = (strcmp(enabledAttr, "true") == 0);
+		const char* scriptAttr = voxelTerrain->Attribute("script");
+		if (scriptAttr)
+			outSettings.script = scriptAttr;
+
+		return true;
+	}
+
 	// EngineConfig.xml's <Startup pauseOnStart=""/> - whether EC_SceneManager::update()
 	// auto-pauses the engine right after the first scene finishes loading (see that call
 	// site's own comment for why that pause exists at all). Defaults to true (existing


### PR DESCRIPTION
## Summary
- Closes #99, the last of the four technical-debt tickets from the terrain-mesh-collision review.
- **Opt-in:** `EC_Game::init()` previously called `m_VoxelChunkSystem.init()` unconditionally for every game. New `EngineConfig.xml` `<VoxelTerrain enabled="" script=""/>` (mirrors `<DebugHTTP>`'s pattern) gates it - a game that doesn't opt in gets zero side effects.
- **Configurable:** rather than bolting on more XML attributes, the other four previously-hardcoded values (chunk shader, tint colour, grid radius - plus the script path itself, which XML does need to say) are now set by the generation script itself via new `volume.setChunkMaterial()`/`setChunkColour()`/`setGridRadius()` Lua calls alongside the existing `volume.setRoot()`. Defaults match the old hardcoded values exactly.

## Test plan
- [x] Full engine build clean
- [x] All 1335 unit test assertions pass
- [x] Live-tested enabled with script defaults - bit-identical debug readout to the pre-change baseline
- [x] Live-tested disabled - zero chunk/worker activity confirmed via log, capsule falls forever as expected
- [x] Live-tested a script temporarily calling `setChunkColour()`/`setGridRadius()` - terrain rendered visibly cyan with more chunks allocated, proving script-driven config has real effect - then reverted

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)